### PR TITLE
docs: Add BSL license for off-Github reference

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,136 @@
+# Release Notes
+
+## v0.2.1
+This is a minor release that resolves several bugs and implements some minor features that are only extensions of features released in v0.2.
+
+### Features
+
+* Add ability to delete multiple documents using filter ([#206](https://github.com/sourcenetwork/defradb/issues/206))
+* Add ability to delete multiple documents, using multiple ids ([#196](https://github.com/sourcenetwork/defradb/issues/196))
+
+### Fixes
+
+* Concurrency control of Document using RWMutex ([#213](https://github.com/sourcenetwork/defradb/issues/213))
+* Only log errors and above when benchmarking ([#261](https://github.com/sourcenetwork/defradb/issues/261))
+* Handle proper type conversion on sort nodes ([#228](https://github.com/sourcenetwork/defradb/issues/228))
+* Return empty array if no values found ([#223](https://github.com/sourcenetwork/defradb/issues/223))
+* Close fetcher on error ([#210](https://github.com/sourcenetwork/defradb/issues/210))
+* Installing binary using defradb name ([#190](https://github.com/sourcenetwork/defradb/issues/190))
+
+### Tooling
+
+* Add short benchmark runner option ([#263](https://github.com/sourcenetwork/defradb/issues/263))
+
+### Documentation
+
+* Add data format changes documentation folder ([#89](https://github.com/sourcenetwork/defradb/issues/89))
+* Correcting typos ([#143](https://github.com/sourcenetwork/defradb/issues/143))
+* Update generated CLI docs ([#208](https://github.com/sourcenetwork/defradb/issues/208))
+* Updated readme with P2P section ([#220](https://github.com/sourcenetwork/defradb/issues/220))
+* Update old or missing license headers ([#205](https://github.com/sourcenetwork/defradb/issues/205))
+* Update git-chglog config and template ([#195](https://github.com/sourcenetwork/defradb/issues/195))
+
+### Refactoring
+
+* Introduction of logging system ([#67](https://github.com/sourcenetwork/defradb/issues/67))
+* Restructure db/txn/multistore structures ([#199](https://github.com/sourcenetwork/defradb/issues/199))
+* Initialize database in constructor ([#211](https://github.com/sourcenetwork/defradb/issues/211))
+* Purge all println and ban it ([#253](https://github.com/sourcenetwork/defradb/issues/253))
+
+### Testing
+
+* Detect and force breaking filesystem changes to be documented ([#89](https://github.com/sourcenetwork/defradb/issues/89))
+* Boost collection test coverage ([#183](https://github.com/sourcenetwork/defradb/issues/183))
+
+### Continuous integration
+
+* Combine the Lint and Benchmark workflows so that the benchmark job depends on the lint job in one workflow ([#209](https://github.com/sourcenetwork/defradb/issues/209))
+* Add rule to only run benchmark if other check are successful ([#194](https://github.com/sourcenetwork/defradb/issues/194))
+* Increase linter timeout ([#230](https://github.com/sourcenetwork/defradb/issues/230))
+
+### Chore
+
+* Remove commented out code ([#238](https://github.com/sourcenetwork/defradb/issues/238))
+* Remove dead code from multi node ([#186](https://github.com/sourcenetwork/defradb/issues/186))
+
+
+
+## v0.2.0
+DefraDB v0.2 is a major pre-production release. Until the stable version 1.0 is reached, the SemVer minor patch number will denote notable releases, which will give the project freedom to experiment and explore potentially breaking changes.
+
+This release is jam-packed with new features and a small number of breaking changes. Read the full changelog for a detailed description. Most notable features include a new Peer-to-Peer (P2P) data synchronization system, an expanded query system to support GroupBy & Aggregate operations, and lastly TimeTraveling queries allowing to query previous states of a document.
+
+Much more than just that has been added to ensure we're building reliable software expected of any database, such as expanded test & benchmark suites, automated bug detection, performance gains, and more.
+
+This release does include a Breaking Change to existing v0.1 databases regarding the internal data model, which affects the "Content Identifiers" we use to generate DocKeys and VersionIDs. If you need help migrating an existing deployment, reach out at hello@source.network or join our Discord at https://discord.source.network.
+
+### Features
+
+* Added Peer-to-Peer networking data synchronization ([#177](https://github.com/sourcenetwork/defradb/issues/177))
+* TimeTraveling (History Traversing) query engine and doc fetcher ([#59](https://github.com/sourcenetwork/defradb/issues/59))
+* Add Document Deletion with a Key ([#150](https://github.com/sourcenetwork/defradb/issues/150))
+* Add support for sum aggregate ([#121](https://github.com/sourcenetwork/defradb/issues/121))
+* Add support for lwwr scalar arrays (full replace on update) ([#115](https://github.com/sourcenetwork/defradb/issues/115))
+* Add count aggregate support ([#102](https://github.com/sourcenetwork/defradb/issues/102))
+* Add support for named relationships ([#108](https://github.com/sourcenetwork/defradb/issues/108))
+* Add multi doc key lookup support ([#76](https://github.com/sourcenetwork/defradb/issues/76))
+* Add basic group by functionality ([#43](https://github.com/sourcenetwork/defradb/issues/43))
+* Update datastore packages to allow use of context ([#48](https://github.com/sourcenetwork/defradb/issues/48))
+
+### Bug fixes
+
+* Only add join if aggregating child object collection ([#188](https://github.com/sourcenetwork/defradb/issues/188))
+* Handle errors generated during input object thunks ([#123](https://github.com/sourcenetwork/defradb/issues/123))
+* Remove new types from in-memory cache on generate error ([#122](https://github.com/sourcenetwork/defradb/issues/122))
+* Support relationships where both fields have the same name ([#109](https://github.com/sourcenetwork/defradb/issues/109))
+* Handle errors generated in fields thunk ([#66](https://github.com/sourcenetwork/defradb/issues/66))
+* Ensure OperationDefinition case has at least one selection([#24](https://github.com/sourcenetwork/defradb/pull/24))
+* Close datastore iterator on scan close ([#56](https://github.com/sourcenetwork/defradb/pull/56)) (resulted in a panic when using limit)
+* Close superseded iterators before orphaning ([#56](https://github.com/sourcenetwork/defradb/pull/56)) (fixes a panic in the join code) 
+* Move discard to after error check ([#88](https://github.com/sourcenetwork/defradb/pull/88)) (did result in panic if transaction creation fails)
+* Check for nil iterator before closing document fetcher ([#108](https://github.com/sourcenetwork/defradb/pull/108))
+
+### Tooling
+* Added benchmark suite ([#160](https://github.com/sourcenetwork/defradb/issues/160))
+
+### Documentation
+
+* Correcting comment typos ([#142](https://github.com/sourcenetwork/defradb/issues/142))
+* Correcting README typos ([#140](https://github.com/sourcenetwork/defradb/issues/140))
+
+### Testing
+
+* Add transaction integration tests ([#175](https://github.com/sourcenetwork/defradb/issues/175))
+* Allow running of tests using badger-file as well as IM options ([#128](https://github.com/sourcenetwork/defradb/issues/128))
+* Add test datastore selection support ([#88](https://github.com/sourcenetwork/defradb/issues/88))
+
+### Refactoring
+
+* Datatype modification protection ([#138](https://github.com/sourcenetwork/defradb/issues/138))
+* Cleanup Linter Complaints and Setup Makefile ([#63](https://github.com/sourcenetwork/defradb/issues/63))
+* Rework document rendering to avoid data duplication and mutation ([#68](https://github.com/sourcenetwork/defradb/issues/68))
+* Remove dependency on concrete datastore implementations from db package ([#51](https://github.com/sourcenetwork/defradb/issues/51))
+* Remove all `errors.Wrap` and update them with `fmt.Errorf`. ([#41](https://github.com/sourcenetwork/defradb/issues/41))
+* Restructure integration tests to provide better visibility ([#15](https://github.com/sourcenetwork/defradb/pull/15))
+* Remove schemaless code branches ([#23](https://github.com/sourcenetwork/defradb/pull/23))
+
+### Performance
+* Add badger multi scan support ([#85](https://github.com/sourcenetwork/defradb/pull/85))
+* Add support for range spans ([#86](https://github.com/sourcenetwork/defradb/pull/86))
+
+### Continous integration
+
+* Use more accurate test coverage. ([#134](https://github.com/sourcenetwork/defradb/issues/134))
+* Disable Codecov's Patch Check
+* Make codcov less strict for now to unblock development ([#125](https://github.com/sourcenetwork/defradb/issues/125))
+* Add codecov config file. ([#118](https://github.com/sourcenetwork/defradb/issues/118))
+* Add workflow that runs a job on AWS EC2 instance. ([#110](https://github.com/sourcenetwork/defradb/issues/110))
+* Add Code Test Coverage with CodeCov ([#116](https://github.com/sourcenetwork/defradb/issues/116))
+* Integrate GitHub Action for golangci-lint Annotations ([#106](https://github.com/sourcenetwork/defradb/issues/106))
+* Add Linter Check to CircleCi ([#92](https://github.com/sourcenetwork/defradb/issues/92))
+
+### Chore
+
+* Remove the S1038 rule of the gosimple linter. ([#129](https://github.com/sourcenetwork/defradb/issues/129))
+* Update to badger v3, and use badger as default in memory store ([#56](https://github.com/sourcenetwork/defradb/issues/56))
+* Make Cid versions consistent ([#57](https://github.com/sourcenetwork/defradb/issues/57))

--- a/docs/release-notes/_category_.json
+++ b/docs/release-notes/_category_.json
@@ -1,5 +1,0 @@
-{
-    "label": "Release Notes",
-    "position": 4
-  }
-  

--- a/docs/release-notes/intro.md
+++ b/docs/release-notes/intro.md
@@ -1,2 +1,0 @@
-# Release Notes
-

--- a/static/BSLv0.2.txt
+++ b/static/BSLv0.2.txt
@@ -1,0 +1,132 @@
+Business Source License 1.1
+
+
+Parameters
+
+
+Licensor:                   Democratized Data (D2) Foundation
+
+
+Licensed Work:              DefraDB v0.2
+                            The Licensed Work is (c) 2022 D2 Foundation.
+
+
+Additional Use Grant:       You may only use the Licensed Work for an
+                            application that is connected  to the SourceHub
+                            mainnet or another protocol connected to the
+                            SourceHub by way of the Inter-Blockchain
+                            Communication (IBC) protocol. 
+
+
+Change Date:                2026-02-07
+
+
+Change License:             Apache License, Version 2.0
+
+
+For information about alternative licensing arrangements for the Software,
+please contact us: license@source.network
+
+
+Notice
+
+
+The Business Source License (this document, or the “License”) is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.
+
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+“Business Source License” is a trademark of MariaDB Corporation Ab.
+
+
+-----------------------------------------------------------------------------
+
+
+Business Source License 1.1
+
+
+Terms
+
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON 
+AN “AS IS” BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, 
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF 
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND 
+TITLE.
+
+
+MariaDB hereby grants you permission to use this License’s text to license
+your works, and to refer to it using the trademark “Business Source License”,
+as long as you comply with the Covenants of Licensor below.
+
+
+Covenants of Licensor
+
+
+In consideration of the right to use this License’s text and the “Business
+Source License” name and trademark, Licensor covenants to MariaDB, and to all 
+other recipients of the licensed work to be provided by Licensor:
+
+
+1. To specify as the Change License the GPL Version 2.0 or any later version, 
+or a license that is compatible with GPL Version 2.0 or a later version, 
+where “compatible” means that software provided under the Change License can 
+be included in a program with software provided under GPL Version 2.0 or a 
+later version. Licensor may specify additional Change Licenses without 
+limitation.
+
+
+2. To either: (a) specify an additional grant of rights to use that does not 
+impose any additional restriction on the right granted in this License, as 
+the Additional Use Grant; or (b) insert the text “None”.
+
+
+3. To specify a Change Date.
+
+
+4. Not to modify this License in any other way.
+
+-----------------------------------------------------------------------------
+


### PR DESCRIPTION
The idea being to be able to reference to the BSL in the defradb binary with the https://docs.source.network/BSLv0.2.txt URL