### PR TITLE
Updated references section ordering

### DIFF
--- a/docs/references/cli/_category_.json
+++ b/docs/references/cli/_category_.json
@@ -1,3 +1,4 @@
 {
-  "label": "CLI Specification"
+  "label": "CLI Specification",
+  "position": 2
 }

--- a/docs/references/query-specification/_category_.json
+++ b/docs/references/query-specification/_category_.json
@@ -1,3 +1,4 @@
 {
-  "label": "Query specification"
+  "label": "Query specification",
+  "position": 1
 }


### PR DESCRIPTION
Quick fix to reorder references section. 

Was CLI then Query. Now Query then CLI.