### PR TITLE
fix: SourceHub docs

### DIFF
--- a/docs/sourcehub/concepts/zanzibar.md
+++ b/docs/sourcehub/concepts/zanzibar.md
@@ -5,9 +5,7 @@ title: Zanzibar Access Control
 
 # Introduction
 
-Zanzibar was first introduced by Google in their [whitepaper](https://research.google/pubs/pub48190/).
-In essence, Zanzibar is an Authorization Service which powers Google's services.
-Its main purpose boils down to answering Access Requests, which in plain English can be translated to the question:
+Zanzibar was first introduced by Google in their [whitepaper](https://research.google/pubs/pub48190/). It is an authorization service which powers Google's services. Its main purpose boils down to answering Access Requests, which in plain English can be translated to the question
 
 > Can user U do operation O over object A?
 
@@ -29,7 +27,6 @@ The book's author should be able to read and edit their own book - meaning the o
 
 These relations exist in virtually every problem domain, so much so there are specialized languages dedicated to representing those relations, such as Description Logic.
 RelBAC exploits these relations in order to figure out permissions.
-
 
 ## Zanzibar's RelBAC
 

--- a/docs/sourcehub/concepts/zanzibar.md
+++ b/docs/sourcehub/concepts/zanzibar.md
@@ -9,9 +9,9 @@ Zanzibar was first introduced by Google in their [whitepaper](https://research.g
 In essence, Zanzibar is an Authorization Service which powers Google's services.
 Its main purpose boils down to answering Access Requests, which in plain English can be translated to the question:
 
-> can user U do operation O over object A?
+> Can user U do operation O over object A?
 
-The remaining of this article introduces Zanzibar's Access Control model, how it was designed to fulfill Access Requests and propose a model to aid understanding.
+The remainder of this article introduces Zanzibar's Access Control model, how it was designed to fulfill Access Requests and propose a model to aid understanding.
 
 ## Relation Based Access Control Model
 
@@ -27,7 +27,7 @@ Furthermore there exists a relation between these two entities, a book was *auth
 The key to RelBAC is noticing that this relation can be used to derive permissions.
 The book's author should be able to read and edit their own book - meaning the operations "read" and "edit" should be allowed for an author.
 
-These relations exist in virtualy every problem domain, so much so there are specialized languages dedicated to representing those relations, such as Descrption Logic.
+These relations exist in virtually every problem domain, so much so there are specialized languages dedicated to representing those relations, such as Description Logic.
 RelBAC exploits these relations in order to figure out permissions.
 
 
@@ -47,7 +47,7 @@ id := string
 ```
 
 A Relation Tuple is a 3-tuple which contains a reference to an object, some named relation and an user.
-The 3-tuple `(article:zanzibar, publisher, coorporation:google)` represents a relationship between the zanzibar article and the google coorporation.
+The 3-tuple `(article:zanzibar, publisher, corporation:google)` represents a relationship between the zanzibar article and the google corporation.
 
 More interestingly however is the variant of `user` given by the pair `(object, relation)`, in Zanzibar's white paper this pair is called `userset`.
 The userset is a convenient way to express a group of users.
@@ -71,7 +71,7 @@ A key insight to grok Zanzibar is to notice that a set of Tuples defines a Graph
 
 In order to vizualise this fact, notice that a Relation Tuple can be rewritten as a pair of pairs: ((object, relation), (object, relation)), let's call the object-relation pairs Relation Nodes.
 The first pair is given by the tuple's Object and Relation as per usual, the second pair is taken to be an userset.
-If we assume relations can be empty, this representation covers all cases mentioend in the original definition.
+If we assume relations can be empty, this representation covers all cases mentioned in the original definition.
 
 With this interpretation, we can start to see the relation graph taking shape.
 Each Relation Tuple actually defines an Edge in the Relation Graph.
@@ -112,14 +112,14 @@ Rules are associated to Relations.
 A final remark: rules are evaluated during runtime, for every Relation Node Zanzibar encounters while searching through the Relation Graph.
 
 
-### Permissions Hiearchy & Computed Usersets
+### Permissions Hierarchy & Computed Usersets
 
-Permission Hiearchy is a big word for a simple idea.
+Permission Hierarchy is a big word for a simple idea.
 It basically means that permission to do some operation implies permission to do some other "weaker" operation.
 
 ie. the permission to write (in most cases) implies the permission to read beforehand.
 
-From a pratical perspective, this feature greatly reduces the administrative burden and complexity associated to managing rules in an Access Control System.
+From a practical perspective, this feature greatly reduces the administrative burden and complexity associated to managing rules in an Access Control System.
 
 Take for instance the previous Relation Graph, repeated here for convenience.
 
@@ -139,21 +139,21 @@ Now, let's walk through an example to see how Zanzibar handles that.
 Suppose we ask Zanzibar to check whether "bob" is a "reader" of "file:readme", zanzibar would:
 
 1. start at the node `("file:readme", "reader")` and look for any rules associated to the `reader` relation.
-2. With the `Computed Userset("owner")` rule, it would create a new Relation Node `("file:readme", "owner")` and set it as a sucessor of `("file:readme", "reader")`
+2. With the `Computed Userset("owner")` rule, it would create a new Relation Node `("file:readme", "owner")` and set it as a successor of `("file:readme", "reader")`
 3. Continue the search through `("file:readme", "owner")`
 
 ![Computed Userset Evaluation](/img/sourcehub/cu-annotated.png)
 
-Using a Computed Userset we sucessfuly added a rule to Zanzibar which automatically derives one relation from another.
+Using a Computed Userset we successfully added a rule to Zanzibar which automatically derives one relation from another.
 This enable users to define a set of global rules for a relation as opposed to adding additional Relation Tuples for each object in the system.
-This powerful mechanism greatly decreases the maintanability cost associated to Relation Tuples.
+This powerful mechanism greatly decreases the maintainability cost associated to Relation Tuples.
 
-### Object Hiearchy & Tuple to Userset
+### Object Hierarchy & Tuple to Userset
 
 Before diving into the Tuple to Userset rule it's important to recall the main idea behind RelBAC: the relations among system objects can be used to derive permissiosn and fulfill Access Requests.
 
 We have seen how to relate objects to users using Relation Tuples.
-Usersets allows us to define hiearchy between users and group them.
+Usersets allows us to define hierarchy between users and group them.
 The missing link so far is how can we use Zanzibar to create Relations between Objects and consequently group them.
 That's where the Tuple to Userset comes in.
 
@@ -168,7 +168,7 @@ Let the Tuples in the system be illustrated by the following Relation Graph:
 The problem at hand is: how to declare that Bob's readme file is under Alice's home directory.
 Furthermore, how can we declare that Alice should be able to read file readme, since it is contained in her directory.
 
-One way to solve the problem regadring the permission is to create a Relation Tuple from the file to the directory.
+One way to solve the problem regarding the permission is to create a Relation Tuple from the file to the directory.
 The tuple `(file:/home/readme, reader, (directory:/home, owner))` will do the trick, by adding the set of directory owners as readers.
 
 ![File System Relation Graph with Relation from File to Directory owners](/img/sourcehub/ttu-relgraph-2.png)
@@ -180,24 +180,24 @@ What we really want is to declare a relation between a file and directory and fr
 
 ![File System Relation Graph parent relation](/img/sourcehub/ttu-relgraph-3.png)
 
-From the image we see that the file is realated to its directory through the `parent` relation.
-This representation explicitely outlines how files and directories are associated in the system.
+From the image we see that the file is related to its directory through the `parent` relation.
+This representation explicitly outlines how files and directories are associated in the system.
 All that is missing is tracing a path from the `/home/readme, reader` node to the `/home, owner` node, completing the chain.
 
-This *could* be done by using a Computed Userset rule pointing from reader to parent and an additional Relation Tuple between the `/home` node and `/home, owner` but that still blurries the line between what is an actual Relation between objects and Access Control rules.
+This *could* be done by using a Computed Userset rule pointing from reader to parent and an additional Relation Tuple between the `/home` node and `/home, owner` but that still blurs the line between what is an actual Relation between objects and Access Control rules.
 The Tuple to Userset rule solves this exact problem.
 
 The Tuple to Userset rule is essentially a Tuple query chained with a Computed Userset rule.
 It takes two arguments: a "Tupleset Filter" and a "Computed Userset Relation".
-The rule first rewrites the current Relation Node using the Tupleset Filter, with the new node it then fetches all sucessors of that node.
-With the resulting sucessor set, it performs a Computed Userset Rewrite using the supplied "Computed Userset Relation".
+The rule first rewrites the current Relation Node using the Tupleset Filter, with the new node it then fetches all successors of that node.
+With the resulting successor set, it performs a Computed Userset Rewrite using the supplied "Computed Userset Relation".
 
 The Tuple to Userset rule is very powerful in that it allows the application to declare a Relation between two objects, thus allowing object hiearchies as we've just explored.
 
 Note however that the main benefit of the `Tuple to Userset` is the fact that it allows an application to create only Tuples which expresses Relations, without requiring additional Tuples which would otherwise exist only for deriving Permission rules.
 This may seem trivial but it has profound implications, the fact that Zazibar supports Relations like these, means that the Application - which ultimately is responsible for creating the Tuples - need not be aware that a Relation Tuple from `/home/readme` to the parent directory needs to be created.
 The rules of access control are inconsequential at the application layer, being contained entirely within Zanzibar.
-The Tuple to Userset is findamental to decouple Permission and Access Control logic from the application because it supports complex hiearchies between objects to be translated into Access Control rules.
+The Tuple to Userset is fundamental to decouple Permission and Access Control logic from the application because it supports complex hiearchies between objects to be translated into Access Control rules.
 
 Finally, let's see the TupleToUserset in action.
 
@@ -208,7 +208,7 @@ Evaluating the TupleToUserset rule requires the following steps:
 1. start at the Relation Node `(file:/home/readme, reader)`.
 2. Evaluate Rule `TupleToUserset(tupleset_filter: "parent", computed_userset: "reader")`
 3. Build a filter using "tupleset_relation" -> `(file:readme, parent)`
-4. Fetch all sucessors of the filter built in step 3 -> `[(directory:/home)]`
+4. Fetch all successors of the filter built in step 3 -> `[(directory:/home)]`
 5. Apply a Computed Userset rewrite rule using the provided "computed_userset" relation for each Relation Node fetched -> `[(directory:/home, reader)]`
 
 Another explanation is given the following image:
@@ -216,29 +216,28 @@ Another explanation is given the following image:
 ![Tuple to Userset Evaluation](/img/sourcehub/ttu-eval.png)
 
 Effectively, the Tuple to Userset added a path from the `/home/readme, reader` node to the `/home, owner` nodes.
-The follwing image shows the edges the rule added:
+The following image shows the edges the rule added:
 
 ![](/img/sourcehub/ttu-relgraph-annotated.png)
 
 ### Rewrite Rule Expression
 
 One final passing note about Rewrite Rules: in Zanzibar a relation can have multiple rewrite rules.
-These rewrite rules are combine to form Rewrite Rule expressions.
+These rewrite rules are combined to form Rewrite Rule expressions.
 
 Each Rewrite Rule effectively returns a set of Relation Nodes (or userset) which are combined using the operation defined in the Rewrite Rule Expression.
 Rules are joined using the familiar set operators: union, difference and intersection.
 
 The set operations are applied to the resulting set of Nodes resulting from evaluating each Rewrite Rule.
-This evaluated final set of Nodes is effectively all the sucessors from a parent Relation Node.
+This evaluated final set of Nodes is effectively all the successors from a parent Relation Node.
 
 ## Conclusion
 
 We've seen how the Relation Tuples actually define a Graph of object-relations, which in turn can be used to resolve Access Requests
 We've also seen how Usersets enables grouping users and applying a Relation to a set of users.
-Finally, we explored how the Use
-rset Rewrite Rules can be used to define a Relation Hiearchy and how it supports Object hiearchies; both of these features are critical to ensure that Access Control Logic stays within Zanzibar.
+Finally, we explored how the Userset Rewrite Rules can be used to define a Relation Hierarchy and how it supports Object hiearchies; both of these features are critical to ensure that Access Control Logic stays within Zanzibar.
 
-Althought the initial mention of the Relation Graph was extremely helpful to illustrate how it works, the reality is that the actual Relation Graph is dynamically built by Zanzibar from the Relation Tuples and by evaluating the Relation Rewrite Rules.
+Although the initial mention of the Relation Graph was extremely helpful to illustrate how it works, the reality is that the actual Relation Graph is dynamically built by Zanzibar from the Relation Tuples and by evaluating the Relation Rewrite Rules.
 The synergy between these two concepts is what powers Zanzibar's Access Control Model.
 
 Under that point of view, we can think of Zanzibar's API as operating over the dynamic Relation Graph.

--- a/docs/sourcehub/getting-started/1-readme.md
+++ b/docs/sourcehub/getting-started/1-readme.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-To get started with SourceHub, we need to download and initialize our local client. This section will utilize the `CLI` but equivalent functionaly is available using the programatic embedded API.
+To get started with SourceHub, we need to download and initialize our local client. This section will utilize the `CLI` but equivalent functionality is available using the programmatic embedded API.
 
 ## 1. Install SourceHub
 First, we will download the SourceHub binary which includes a client.
@@ -10,11 +10,11 @@ You can get precompiled binaries from our Github Release page [here](https://git
 cd $HOME
 wget https://github.com/sourcenetwork/sourcehub/releases/download/v0.2.0/sourcehubd
 chmod +x sourcehubd
-sudo mv /usr/bin
+sudo mv sourcehubd /usr/bin
 ```
 
 ### From Source Code
-You can download the code and compile your own binaries if you prefer. However you will need a local installation of the go toolchain at a minimum version of 1.22
+You can download the code and compile your own binaries if you prefer. However you will need a local installation of the Go toolchain with a minimum version of 1.22.
 ```bash
 cd $HOME
 git clone https://github.com/sourcenetwork/sourcehub

--- a/docs/sourcehub/getting-started/2-account.md
+++ b/docs/sourcehub/getting-started/2-account.md
@@ -7,7 +7,7 @@ The following command will generate a new random private key with the name `<wal
 ```bash
 sourcehubd keys add <wallet_name>
 ```
-This will output the newly generated key public key, address, and mnemonic (make sure to backup the mnemonic)
+This will output the newly generated public key, address, and mnemonic (make sure to back up the mnemonic).
 
 ![Wallet output](/img/sourcehub/key-add-output.png)
 
@@ -20,7 +20,7 @@ sourcehubd keys add --recover <wallet_name>
 Then input your existing mnemonic when prompted.
 
 :::warning
-You MUST ensure that you sufficiently backup your mnemonic. Failure to do so may result in lost access to your wallet.
+You MUST ensure that you sufficiently back up your mnemonic. Failure to do so may result in lost access to your wallet.
 :::
 
 ## Configuring client
@@ -43,4 +43,4 @@ Finally, we can verify that our account exists and that it has been loaded with 
 sourcehubd query bank balances <wallet_name>
 ```
 
-That it, we now have a newly generated local wallet via the `CLI` client. Now we can interact with the network! First up, we will be creating an ACP policy, seeding it with some state, and executing authorization checks.
+That's it, we now have a newly generated local wallet via the `CLI` client. Now we can interact with the network! First up, we will be creating an ACP policy, seeding it with some state, and executing authorization checks.

--- a/docs/sourcehub/getting-started/3-create-a-policy.md
+++ b/docs/sourcehub/getting-started/3-create-a-policy.md
@@ -13,7 +13,7 @@ The SourceHub ACP Module is a [Zanzibar](/sourcehub/concepts/zanzibar) based glo
 - **Permissions**: Computed queries over resources, relations, and even other permissions (they're recursive!).
 
 ## Example
-Lets create a very basic example policy which defines a single resource named `note` with both an `owner` and `collaborator` relation which are both of type `actor`.
+Let's create a very basic example policy which defines a single resource named `note` with both an `owner` and `collaborator` relation which are both of type `actor`.
 
 Create a file named `basic-policy.yaml` and paste the following:
 ```yaml
@@ -40,9 +40,9 @@ resources:
 
 Here we are also defining 3 permissions. 
 
-The `read` permission is expressed as `owner + reader` which means *if* you have either an `owner` or `reader` relation *then* you have the `read`.
+The `read` permission is expressed as `owner + collaborator` which means *if* you have either an `owner` or `collaborator` relation *then* you have the `read` permission.
 
-Both the `edit` and `delete` permissions are reserved soley for those with the `owner` relation.
+Both the `edit` and `delete` permissions are reserved solely for those with the `owner` relation.
 
 :::info
 Traditionally we define relations as nouns and permissions as verbs. This is because we often understand authorization as some *thing* (noun) performing some *action* (verb) on some resource. 
@@ -51,13 +51,13 @@ Traditionally we define relations as nouns and permissions as verbs. This is bec
 ### Upload Policy
 Now that we have defined our policy, we can upload it to SourceHub.
 ```bash
-sourcehub tx acp create-policy basic-policy.yaml --from <wallet_name>
+sourcehubd tx acp create-policy basic-policy.yaml --from <wallet_name>
 ```
 
 Then, to get the policy we can list the existing policies.
 
 ```bash
-sourcehub q acp policy-ids
+sourcehubd q acp policy-ids
 ```
 
 ![Policy IDs](/img/sourcehub/policy-ids-1.png)

--- a/docs/sourcehub/getting-started/4-acp-check.md
+++ b/docs/sourcehub/getting-started/4-acp-check.md
@@ -5,7 +5,7 @@ title: Access Requests
 
 Now that we have an existing account and created policy, we're going to seed it with some resources and evaluate some `Check` requests.
 
-> A [`Check`](zanzibar-concept) request is how we determine if a given action on a reasource by an actor is allowed. 
+> A [`Check`](zanzibar-concept) request is how we determine if a given action on a resource by an actor is allowed. 
 
 We are using the policy we created for our basic note app from the last step, which has a policy id of `a3cc042579639c4b36357217a197e0bb17bdbb54ff322d4b52e4bba4d19548bf`. 
 
@@ -16,7 +16,7 @@ The full command is:
 sourcehubd tx acp direct-policy-cmd register-object a3cc042579639c4b36357217a197e0bb17bdbb54ff322d4b52e4bba4d19548bf note alice-grocery-list --from <wallet_name>
 ```
 
-We now have created the the `alice-grocery-list` and registered the `owner` as whatever wallet you used for `<wallet_name>`.
+We now have created the `alice-grocery-list` and registered the `owner` as whatever wallet you used for `<wallet_name>`.
 
 To verify this, we can run a request to inspect the resource owner.
 ```bash
@@ -33,7 +33,7 @@ After registering an object and verifying its owner, we can add a collaborator, 
 
 We are going to introduce a new actor `BOB` who has an identity `did:key:z6Mkmyi3eCUYJ6w2fbgpnf77STLcnMf6tuJ56RQmrFjce6XS`.
 
-To add `BOB` as a `collaborator` (which is a specific relation defined on the [policy](example-basic-policy)) we can issue a a `set-relationship <policy-id> <resource-name> <resource-id> <relation> <subject>` where `<relation>` is `collaborator` and `<subject>` is the BOB identity above (`did:key:z6Mkmyi3eCUYJ6w2fbgpnf77STLcnMf6tuJ56RQmrFjce6XS`).
+To add `BOB` as a `collaborator` (which is a specific relation defined on the [policy](example-basic-policy)) we can issue a `set-relationship <policy-id> <resource-name> <resource-id> <relation> <subject>` where `<relation>` is `collaborator` and `<subject>` is the BOB identity above (`did:key:z6Mkmyi3eCUYJ6w2fbgpnf77STLcnMf6tuJ56RQmrFjce6XS`).
 ```
 sourcehubd tx acp direct-policy-cmd set-relationship a3cc042579639c4b36357217a197e0bb17bdbb54ff322d4b52e4bba4d19548bf note alice-grocery-list collaborator did:key:z6Mkmyi3eCUYJ6w2fbgpnf77STLcnMf6tuJ56RQmrFjce6XS --from <wallet_name>
 ```
@@ -45,7 +45,7 @@ sourcehubd q acp verify-access-request a3cc042579639c4b36357217a197e0bb17bdbb54f
 
 Which will return `valid: true`.
 
-Lets check for a permission that Bob *shouldn't* have, like `edit` which is reserved for `OWNERs`.
+Let's check for a permission that Bob *shouldn't* have, like `edit` which is reserved for `OWNERs`.
 ```bash
 sourcehubd q acp verify-access-request a3cc042579639c4b36357217a197e0bb17bdbb54ff322d4b52e4bba4d19548bf did:key:z6Mkmyi3eCUYJ6w2fbgpnf77STLcnMf6tuJ56RQmrFjce6XS note:alice-grocery-list#edit
 ```

--- a/docs/sourcehub/overview.md
+++ b/docs/sourcehub/overview.md
@@ -7,7 +7,7 @@ slug: /sourcehub
 
 ![SourceHub Overview](/img/sourcehub-cover-copy.png)
 
-SourceHub is the Source Network's trust protocol, which fascilitates trusted and authenticated sharing and collaboration of data across the network and beyond. It utilizes [CometBFT](https://cometbft.com/) consensus and is built on the [Cosmos SDK](link) to provide us with a solid technical foundation to enable our decentralized infrastructure and application-specific chain.
+SourceHub is the Source Network's trust protocol, which facilitates trusted and authenticated sharing and collaboration of data across the network and beyond. It utilizes [CometBFT](https://cometbft.com/) consensus and is built on the [Cosmos SDK](link) to provide us with a solid technical foundation to enable our decentralized infrastructure and application-specific chain.
 
 The primary functions of SourceHub are:
 - **ACP Module**: A decentralized authorization engine, inspired in part by [Google Zanzibar's](/sourcehub/concepts/zanzibar) Relational Based Access Control (RelBAC)
@@ -18,6 +18,6 @@ The primary functions of SourceHub are:
 
 ---
 
-Although SourceHub is an indepdant system with self-contained functionality - like the rest of the Source Stack - it is designed to work in conjunction with [DefraDB](/defradb) nodes to help fascilitate trust in its peer-to-peer architecture. 
+Although SourceHub is an independent system with self-contained functionality - like the rest of the Source Stack - it is designed to work in conjunction with [DefraDB](/defradb) nodes to help facilitate trust in its peer-to-peer architecture. 
 
 ![SourceHub+DefraDB](/img/sourcehub/trust-protocol-defradb.png)


### PR DESCRIPTION
Fixes inconsistencies and typos across multiple sections of the SourceHub documentation.