### PR TITLE
fix: README lint errors and expand vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Most changes are reflected live without having to restart the server.
 
 This website is built using [Docusaurus 2](https://docusaurus.io/).
 
-Documentation is written using [common markdown syntax](https://commonmark.org/help/) or [MDX syntax](https://mdxjs.com/docs/what-is-mdx/#mdx-syntax) - the file extension will determine the syntax (.md for common markdown and .mdx for MDX).
+Documentation is written using [common markdown syntax](https://commonmark.org/help/) or [MDX syntax](https://mdxjs.com/docs/what-is-mdx/#mdx-syntax). Use `.md` files for common markdown and `.mdx` files for MDX.
 
 ## Deployment
 
-The website is automatically deployed using Cloudfare Pages.
+The website is automatically deployed using Cloudflare Pages.
 
 ## Contributing
 
-Feedback and pull requests appreciated!
+Feedback and pull requests appreciated.

--- a/styles/config/vocabularies/DefraDB/accept.txt
+++ b/styles/config/vocabularies/DefraDB/accept.txt
@@ -18,6 +18,9 @@ ArangoDB
 CouchDB
 Redis
 
+# Services & Platforms
+Cloudflare
+
 # Technical Terms - Edge Computing
 [Ee]dge-first
 [Ll]ocal-first
@@ -87,6 +90,15 @@ DSL
 ACP
 CID
 CIDs
+
+# License acronyms (Creative Commons)
+CC
+BY
+SA
+
+# File extensions and formats
+mdx
+MDX
 
 # Industry Terms
 Big Tech


### PR DESCRIPTION
## Summary
- Fix typo: Cloudfare → Cloudflare
- Remove exclamation point from Contributing section
- Reword MDX file extension sentence for clarity
- Add Cloudflare, CC/BY/SA, MDX to accepted vocabulary

## Test plan
- [x] `vale --minAlertLevel=error README.md` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)