### PR TITLE
Shrinks the searchbar on skinny displays.

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -110,11 +110,11 @@ html[data-theme="dark"] {
 
   &__brand {
     margin-right: rem(40px);
+    flex-shrink: 0;
   }
 
   &__logo {
     max-width: rem(230px);
-    width: 100%;
     margin-left: rem(30px);
     @media (max-width: 996px) {
       margin-left: rem(20px);
@@ -420,6 +420,14 @@ body .DocSearch {
     padding-right: 10rem;
     &:after {
       content: " ...";
+    }
+
+    // Between ~996px and 1200px, shrink the search bar so the logo
+    // (and other navbar items) keep their natural width. We start at
+    // 996px (rather than 997px) to avoid a sub-pixel gap where neither
+    // the mobile navbar rules nor this rule apply.
+    @media (min-width: 996px) and (max-width: 1200px) {
+      padding-right: 2rem;
     }
   }
 


### PR DESCRIPTION
The Source logo was getting squished on shinny displays. This change shrinks the searchbar when necessary to make space for the logo to stay at full width without causing the other navbar elements to overlap.

Normal view (search bar not shrank):

<img width="1386" height="1036" alt="normal" src="https://github.com/user-attachments/assets/b25950ea-b395-4bca-af3c-9975a9066f1b" />

Skinny view (search bar width reduced):

<img width="1167" height="1036" alt="shrank" src="https://github.com/user-attachments/assets/d9b7ad8e-541c-4df1-a364-bc1aade887b9" />
