### PR TITLE
Ignores topbar nav for external-link icons.

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -556,7 +556,7 @@ body .DocSearch {
     var(--ifm-color-emphasis-100) 100%
   );
 }
-// External link icon indicator.
+// External link icon indicator (excluded from navbar).
 a[target="_blank"]::after {
   content: "";
   display: inline-block;
@@ -571,4 +571,7 @@ a[target="_blank"]::after {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.75 2a1.75 1.75 0 0 0-1.75 1.75v8.5c0 .966.784 1.75 1.75 1.75h8.5A1.75 1.75 0 0 0 14 12.25v-3.5a.75.75 0 0 0-1.5 0v3.5a.25.25 0 0 1-.25.25h-8.5a.25.25 0 0 1-.25-.25v-8.5a.25.25 0 0 1 .25-.25h3.5a.75.75 0 0 0 0-1.5h-3.5zm6.25 0a.75.75 0 0 0 0 1.5h2.19L6.72 9.03a.75.75 0 1 0 1.06 1.06l5.5-5.5v2.19a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-4.25z'/%3E%3C/svg%3E");
   -webkit-mask-size: contain;
   -webkit-mask-repeat: no-repeat;
+}
+.navbar a[target="_blank"]::after {
+  display: none;
 }


### PR DESCRIPTION
Closes https://github.com/sourcenetwork/docs.source.network/issues/220

External links in the navbar were showing the arrow-box icon that `a[target="_blank"]::after` adds in `custom.scss`. That icon makes sense in body content; it doesn't belong in the nav.

Instead of rewriting the original rule with `:not()` (which doesn't reliably accept complex selectors like `:not(.navbar a)` across older browsers), this adds a targeted override: `.navbar a[target="_blank"]::after { display: none; }`. The original rule is untouched.

<img width="1582" height="1036" alt="Screenshot 2026-06-03 at 14 18 08" src="https://github.com/user-attachments/assets/e141dc95-a8be-4e44-9043-82f1255cc19f" />