### PR TITLE
Collapsible code blocks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -178,6 +178,14 @@ const config = {
             className: 'code-block-valid-line',
             line: 'valid',
           },
+          {
+            className: 'code-block-collapse',
+            line: 'collapse',
+          },
+          {
+            className: 'code-block-no-collapse',
+            line: 'no-collapse',
+          },
         ],
       },
       algolia: {
@@ -186,7 +194,9 @@ const config = {
         indexName: "source-docs",
       },
     }),
-  clientModules: [],
+  clientModules: [
+    require.resolve('./src/plugins/code-blocks.js')
+  ],
   plugins: [
     [
       require.resolve("./src/plugins/plausible"),

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -605,7 +605,7 @@ div.language-graphql + div.language-json,
 div.language-http + div.language-json,
 div.language-shell + div.language-json,
 div.language-json + div.language-json {
-  margin-top: calc(var(--ifm-leading) * -1);
+  margin-top: calc((var(--ifm-leading) * -1) + 2px);
 }
 
 /* Style for code blocks starting with `// invalid` */
@@ -653,4 +653,22 @@ main.docMainContainer_TBSr a[target="_blank"]::after {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.75 2a1.75 1.75 0 0 0-1.75 1.75v8.5c0 .966.784 1.75 1.75 1.75h8.5A1.75 1.75 0 0 0 14 12.25v-3.5a.75.75 0 0 0-1.5 0v3.5a.25.25 0 0 1-.25.25h-8.5a.25.25 0 0 1-.25-.25v-8.5a.25.25 0 0 1 .25-.25h3.5a.75.75 0 0 0 0-1.5h-3.5zm6.25 0a.75.75 0 0 0 0 1.5h2.19L6.72 9.03a.75.75 0 1 0 1.06 1.06l5.5-5.5v2.19a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-4.25z'/%3E%3C/svg%3E");
   -webkit-mask-size: contain;
   -webkit-mask-repeat: no-repeat;
+}
+
+/* Collapsible code blocks */
+.theme-code-block{
+  pre.collapsed {
+    max-height: 150px;
+    overflow: hidden;
+    cursor: pointer;
+    mask-image: linear-gradient(to bottom, black, transparent 150px);
+  }
+}
+.theme-code-block {
+  .display-all {
+    height: 2.5rem;
+    text-align: center;
+    cursor: pointer;
+    font-weight: 600;
+  }
 }

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -570,6 +570,10 @@ body .DocSearch {
   );
 }
 
+.alert {
+  --ifm-link-color: var(--ifm-color-primary);
+}
+
 /* Color for version selector */
 .navbar__item.dropdown {
   .navbar__link {

--- a/src/plugins/code-blocks.js
+++ b/src/plugins/code-blocks.js
@@ -1,0 +1,66 @@
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+var codeMaxLines = 8  // css 150px is in sync with this
+
+const doYourCustomStuff = () => {
+	let blocks = document.querySelectorAll('main div.theme-code-block')
+	if ( blocks.length == 0 ) return
+	let randomBlockStyle = window.getComputedStyle(blocks[0].querySelector('pre'))
+	// line-height px value for pre inside code blocks
+	let codeLineHeight = parseFloat(randomBlockStyle.getPropertyValue('line-height'))
+	
+	blocks.forEach(collapseCodeBlock)
+	
+	function collapseCodeBlock(block) {
+		if ( ! shouldCollapseBlock(block) ) return
+		let pre = block.querySelector('pre')
+		let totalLines = Math.ceil(pre.clientHeight / codeLineHeight)
+		pre.classList.add('collapsed')
+
+		var displayAll = document.createElement('div')
+		displayAll.classList.add('display-all')
+		pre.addEventListener('click', expandCodeBlock)
+		var displayAllLink = document.createElement('a')
+		displayAllLink.innerHTML = `Expand (${totalLines} lines)`
+		block.appendChild(displayAll)
+		displayAll.appendChild(displayAllLink)
+	}
+
+	function shouldCollapseBlock(block) {
+		var linesTolerance = 4 // don't collapse if block is longer but within tolerance
+		if (block.offsetHeight < (codeMaxLines + linesTolerance) * codeLineHeight)
+			return false
+		if ( block.querySelector('.code-block-collapse') != null )
+			return true
+		if ( block.querySelector('.code-block-no-collapse') != null )
+			return false
+		if ( block.querySelector('.codeBlockTitle_OeMC') != null 
+		&& block.querySelector('.codeBlockTitle_OeMC').textContent == 'Result' )
+			return true
+		return false
+	}
+
+	function expandCodeBlock(e) {
+		e.preventDefault()
+		let block = e.target.closest('div.theme-code-block')
+		let pre = block.querySelector('pre')
+		pre.classList.remove('collapsed')
+		block.removeChild(block.querySelector('div.display-all'))
+  }
+}
+
+export function onRouteDidUpdate({location, previousLocation}) {
+  // Don't execute if we are still on the same page; the lifecycle may be fired
+  // because the hash changes (e.g. when navigating between headings)
+  if (location.pathname === previousLocation?.pathname) return;
+  doYourCustomStuff();
+}
+
+if (ExecutionEnvironment.canUseDOM) {
+  // We also need to setCodeRevealTriggers when the page first loads; otherwise,
+  // after reloading the page, these triggers will not be set until the user
+  // navigates somewhere.
+  window.addEventListener('load', () => {
+    setTimeout(doYourCustomStuff, 1000);
+  });
+}

--- a/src/plugins/code-blocks.js
+++ b/src/plugins/code-blocks.js
@@ -1,51 +1,51 @@
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
-var codeMaxLines = 8  // css 150px is in sync with this
+var maxLines = 8  // css 150px is in sync with this
 
-const doYourCustomStuff = () => {
-	let blocks = document.querySelectorAll('main div.theme-code-block')
-	if ( blocks.length == 0 ) return
-	let randomBlockStyle = window.getComputedStyle(blocks[0].querySelector('pre'))
-	// line-height px value for pre inside code blocks
-	let codeLineHeight = parseFloat(randomBlockStyle.getPropertyValue('line-height'))
-	
-	blocks.forEach(collapseCodeBlock)
-	
-	function collapseCodeBlock(block) {
-		if ( ! shouldCollapseBlock(block) ) return
-		let pre = block.querySelector('pre')
-		let totalLines = Math.ceil(pre.clientHeight / codeLineHeight)
-		pre.classList.add('collapsed')
+const collapseBlocks = () => {
+  let blocks = document.querySelectorAll('main div.theme-code-block')
+  if ( blocks.length == 0 ) return
+  let randomBlockStyle = window.getComputedStyle(blocks[0].querySelector('pre'))
+  // line-height px value for pre inside code blocks
+  let lineHeight = parseFloat(randomBlockStyle.getPropertyValue('line-height'))
 
-		var displayAll = document.createElement('div')
-		displayAll.classList.add('display-all')
-		pre.addEventListener('click', expandCodeBlock)
-		var displayAllLink = document.createElement('a')
-		displayAllLink.innerHTML = `Expand (${totalLines} lines)`
-		block.appendChild(displayAll)
-		displayAll.appendChild(displayAllLink)
-	}
+  blocks.forEach(collapseBlock)
 
-	function shouldCollapseBlock(block) {
-		var linesTolerance = 4 // don't collapse if block is longer but within tolerance
-		if (block.offsetHeight < (codeMaxLines + linesTolerance) * codeLineHeight)
-			return false
-		if ( block.querySelector('.code-block-collapse') != null )
-			return true
-		if ( block.querySelector('.code-block-no-collapse') != null )
-			return false
-		if ( block.querySelector('.codeBlockTitle_OeMC') != null 
-		&& block.querySelector('.codeBlockTitle_OeMC').textContent == 'Result' )
-			return true
-		return false
-	}
+  function collapseBlock(block) {
+      if ( ! shouldCollapseBlock(block) ) return
+      let pre = block.querySelector('pre')
+      pre.classList.add('collapsed')
 
-	function expandCodeBlock(e) {
-		e.preventDefault()
-		let block = e.target.closest('div.theme-code-block')
-		let pre = block.querySelector('pre')
-		pre.classList.remove('collapsed')
-		block.removeChild(block.querySelector('div.display-all'))
+      let totalLines = Math.ceil(pre.clientHeight / lineHeight)
+      let displayAll = document.createElement('div')
+      displayAll.classList.add('display-all')
+      pre.addEventListener('click', expandBlock)  // clicking anywhere on the code block expands it
+      let displayAllLink = document.createElement('a')
+      displayAllLink.innerHTML = `Expand (${totalLines} lines)`
+      block.appendChild(displayAll)
+      displayAll.appendChild(displayAllLink)
+  }
+
+  function shouldCollapseBlock(block) {
+    let lineTolerance = 4 // don't collapse if block is longer but within tolerance
+    if ( block.offsetHeight < (maxLines + lineTolerance) * lineHeight )
+      return false
+    if ( block.querySelector('.code-block-collapse') != null )
+      return true
+    if ( block.querySelector('.code-block-no-collapse') != null )
+      return false
+    if ( block.querySelector('.codeBlockTitle_OeMC') != null
+    && block.querySelector('.codeBlockTitle_OeMC').textContent == 'Result' )
+      return true
+    return false
+  }
+
+  function expandBlock(e) {
+    e.preventDefault()
+    let block = e.target.closest('div.theme-code-block')
+    let pre = block.querySelector('pre')
+    pre.classList.remove('collapsed')
+    block.querySelector('div.display-all')?.remove()
   }
 }
 
@@ -53,7 +53,7 @@ export function onRouteDidUpdate({location, previousLocation}) {
   // Don't execute if we are still on the same page; the lifecycle may be fired
   // because the hash changes (e.g. when navigating between headings)
   if (location.pathname === previousLocation?.pathname) return;
-  doYourCustomStuff();
+  collapseBlocks();
 }
 
 if (ExecutionEnvironment.canUseDOM) {
@@ -61,6 +61,6 @@ if (ExecutionEnvironment.canUseDOM) {
   // after reloading the page, these triggers will not be set until the user
   // navigates somewhere.
   window.addEventListener('load', () => {
-    setTimeout(doYourCustomStuff, 1000);
+    setTimeout(collapseBlocks, 1000);
   });
 }


### PR DESCRIPTION
By default it will collapse any *result* code blocks longer than 8 lines (unless marked with `# no-collapse`), and blocks marked with `# collapse`. Blocks longer than 8 lines but shorter than 12 don't get collapsed, to avoid the phenomenon of "expand for nothing".