### PR TITLE
LLM plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -227,6 +227,16 @@ const config = {
         },
       },
     ],
+    [
+      "docusaurus-plugin-llms",
+      {
+        docsDir: "content",
+        generateLLMsTxt: true,
+        generateLLMsFullTxt: true,
+        excludeImports: true,
+        removeDuplicateHeadings: true,
+      },
+    ],
     // DefraDB instance
     [
       "@docusaurus/plugin-content-docs",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -230,11 +230,25 @@ const config = {
     [
       "docusaurus-plugin-llms",
       {
-        docsDir: "content",
+        docsDir: "docs",
+        logLevel: "verbose",
         generateLLMsTxt: true,
-        generateLLMsFullTxt: true,
-        excludeImports: true,
+        generateLLMsFullTxt: false,
+        excludeImports: true,  // remove js import statements from MDX files
         removeDuplicateHeadings: true,
+        // Generate individual markdown files and link to them from llms.txt.
+        // This doesn't seem to properly generate md files, but 
+        generateMarkdownFiles: true,
+        ignoreFiles: ['BSL-License.md',],
+        customLLMFiles: [
+        {
+          filename: 'defradb/llms.txt',
+          title: 'DefraDB documentation',
+          description: 'Documentation for DefraDB',
+          includePatterns: ['docs/defradb/**/*.md'],
+          fullContent: false,
+        },
+      ]
       },
     ],
     // DefraDB instance

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -241,6 +241,7 @@ const config = {
         // However, the other extension doesn't generate md files with the same dir structure as
         // plugin-llms expects, so we can't pair them and link to md files in llms.txt.
         generateMarkdownFiles: false,
+        addMdExtension: false,
         ignoreFiles: ['BSL-License.md',],
         customLLMFiles: [
           {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -230,6 +230,7 @@ const config = {
     [
       "docusaurus-plugin-llms",
       {
+        // generate a site-wide file and one specific for each product
         docsDir: "docs",
         logLevel: "verbose",
         generateLLMsTxt: true,
@@ -246,6 +247,27 @@ const config = {
           title: 'DefraDB documentation',
           description: 'Documentation for DefraDB',
           includePatterns: ['docs/defradb/**/*.md'],
+          fullContent: false,
+        },
+        {
+          filename: 'lensvm/llms.txt',
+          title: 'LensVM documentation',
+          description: 'Documentation for LensVM',
+          includePatterns: ['docs/lensvm/**/*.md'],
+          fullContent: false,
+        },
+        {
+          filename: 'orbis/llms.txt',
+          title: 'Orbis documentation',
+          description: 'Documentation for Orbis',
+          includePatterns: ['docs/orbis/**/*.md'],
+          fullContent: false,
+        },
+        {
+          filename: 'sourcehub/llms.txt',
+          title: 'Sourcehub documentation',
+          description: 'Documentation for Sourcehub',
+          includePatterns: ['docs/sourcehub/**/*.md'],
           fullContent: false,
         },
       ]

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -230,47 +230,48 @@ const config = {
     [
       "docusaurus-plugin-llms",
       {
-        // generate a site-wide file and one specific for each product
+        // Generate a site-wide file and one specific for each product
         docsDir: "docs",
-        logLevel: "verbose",
+        // logLevel: "verbose",
         generateLLMsTxt: true,
         generateLLMsFullTxt: false,
         excludeImports: true,  // remove js import statements from MDX files
         removeDuplicateHeadings: true,
-        // Generate individual markdown files and link to them from llms.txt.
-        // This doesn't seem to properly generate md files, but 
-        generateMarkdownFiles: true,
+        // generateMarkdownFiles doesn't seem to properly generate md files, and another extension does it for us.
+        // However, the other extension doesn't generate md files with the same dir structure as
+        // plugin-llms expects, so we can't pair them and link to md files in llms.txt.
+        generateMarkdownFiles: false,
         ignoreFiles: ['BSL-License.md',],
         customLLMFiles: [
-        {
-          filename: 'defradb/llms.txt',
-          title: 'DefraDB documentation',
-          description: 'Documentation for DefraDB',
-          includePatterns: ['docs/defradb/**/*.md'],
-          fullContent: false,
-        },
-        {
-          filename: 'lensvm/llms.txt',
-          title: 'LensVM documentation',
-          description: 'Documentation for LensVM',
-          includePatterns: ['docs/lensvm/**/*.md'],
-          fullContent: false,
-        },
-        {
-          filename: 'orbis/llms.txt',
-          title: 'Orbis documentation',
-          description: 'Documentation for Orbis',
-          includePatterns: ['docs/orbis/**/*.md'],
-          fullContent: false,
-        },
-        {
-          filename: 'sourcehub/llms.txt',
-          title: 'Sourcehub documentation',
-          description: 'Documentation for Sourcehub',
-          includePatterns: ['docs/sourcehub/**/*.md'],
-          fullContent: false,
-        },
-      ]
+          {
+            filename: 'defradb/llms.txt',
+            title: 'DefraDB documentation',
+            description: 'Documentation for DefraDB',
+            includePatterns: ['docs/defradb/**/*.md'],
+            fullContent: false,
+          },
+          {
+            filename: 'lensvm/llms.txt',
+            title: 'LensVM documentation',
+            description: 'Documentation for LensVM',
+            includePatterns: ['docs/lensvm/**/*.md'],
+            fullContent: false,
+          },
+          {
+            filename: 'orbis/llms.txt',
+            title: 'Orbis documentation',
+            description: 'Documentation for Orbis',
+            includePatterns: ['docs/orbis/**/*.md'],
+            fullContent: false,
+          },
+          {
+            filename: 'sourcehub/llms.txt',
+            title: 'Sourcehub documentation',
+            description: 'Documentation for Sourcehub',
+            includePatterns: ['docs/sourcehub/**/*.md'],
+            fullContent: false,
+          },
+        ]
       },
     ],
     // DefraDB instance

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "docs.source.network",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/preset-classic": "3.9.0",
+        "@docusaurus/core": "^3.10.1",
+        "@docusaurus/preset-classic": "^3.10.1",
         "@mdx-js/react": "^3.0.0",
         "@svgr/webpack": "^7.0.0",
         "clsx": "^1.2.1",
@@ -23,125 +23,56 @@
         "url": "^0.11.3"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.9.0",
-        "@docusaurus/tsconfig": "^3.9.0",
+        "@docusaurus/module-type-aliases": "^3.10.1",
+        "@docusaurus/tsconfig": "^3.10.1",
+        "docusaurus-plugin-llms": "^0.4.0",
         "glob": "^10.2.2",
         "simple-git": "^3.17.0",
         "tmp": "^0.2.1",
         "typescript": "^5.0.2"
       }
     },
-    "node_modules/@ai-sdk/gateway": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.0.tgz",
-      "integrity": "sha512-Gj0PuawK7NkZuyYgO/h5kDK/l6hFOjhLdTq3/Lli1FTl47iGmwhH1IZQpAL3Z09BeFYWakcwUmn02ovIm2wy9g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.12",
-        "@vercel/oidc": "3.0.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
-      "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.12.tgz",
-      "integrity": "sha512-ZtbdvYxdMoria+2SlNarEk6Hlgyf+zzcznlD55EAl+7VZvJaSg2sqPvwArY7L6TfDEDJsnCq0fdhBSkYo0Xqdg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.5"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/react": {
-      "version": "2.0.76",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.76.tgz",
-      "integrity": "sha512-ggAPzyaKJTqUWigpxMzI5DuC0Y3iEpDUPCgz6/6CpnKZY/iok+x5xiZhDemeaP0ILw5IQekV0kdgBR8JPgI8zQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "3.0.12",
-        "ai": "5.0.76",
-        "swr": "^2.2.5",
-        "throttleit": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.25.76 || ^4.1.8"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@algolia/abtesting": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.6.1.tgz",
-      "integrity": "sha512-wV/gNRkzb7sI9vs1OneG129hwe3Q5zPj7zigz3Ps7M5Lpo2hSorrOnXNodHEOV+yXE/ks4Pd+G3CDFIjFTWhMQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.0.tgz",
+      "integrity": "sha512-kGvHfBa9oQCvZh0YXeguSToBD9GNJ+gzUZQ9KPTg+KSsM36obYcsKPoX0NnlJtPflHXu7RkMaIi44xs9meR6Zw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.40.1",
-        "@algolia/requester-browser-xhr": "5.40.1",
-        "@algolia/requester-fetch": "5.40.1",
-        "@algolia/requester-node-http": "5.40.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
-      "integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.8.tgz",
+      "integrity": "sha512-3YEorYg44niXcm7gkft3nXYItHd44e8tmh4D33CTszPgP0QWkaLEaFywiNyJBo7UL/mqObA/G9RYuU7R8tN1IA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
-        "@algolia/autocomplete-shared": "1.19.2"
+        "@algolia/autocomplete-plugin-algolia-insights": "1.19.8",
+        "@algolia/autocomplete-shared": "1.19.8"
       }
     },
     "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
-      "integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.8.tgz",
+      "integrity": "sha512-ZvJWO8ZZJDpc1LNM2TTBdmQsZBLMR4rU5iNR2OYvEeFBiaf/0ESnRSSLQbryarJY4SVxtoz6A2ZtDMNM+iQEAA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.19.2"
+        "@algolia/autocomplete-shared": "1.19.8"
       },
       "peerDependencies": {
         "search-insights": ">= 1 < 3"
       }
     },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
-      "integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.8.tgz",
+      "integrity": "sha512-h5hf2t8ejF6vlOgvLaZzQbWs5SyH2z4PAWygNAvvD/2RI29hdQ54ldUGwqVuj9Srs+n8XUKTPUqb7fvhBhQrnQ==",
       "license": "MIT",
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
@@ -149,99 +80,99 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.40.1.tgz",
-      "integrity": "sha512-cxKNATPY5t+Mv8XAVTI57altkaPH+DZi4uMrnexPxPHODMljhGYY+GDZyHwv9a+8CbZHcY372OkxXrDMZA4Lnw==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.0.tgz",
+      "integrity": "sha512-Zt2GjIm7vsaf7K23tk5JmtcVNc38G9p0C2L2Lrm06miyLE/NL2etHtHInvuLc1DjxTp7Y2nId4X/tzwo372K8Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.40.1",
-        "@algolia/requester-browser-xhr": "5.40.1",
-        "@algolia/requester-fetch": "5.40.1",
-        "@algolia/requester-node-http": "5.40.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.40.1.tgz",
-      "integrity": "sha512-XP008aMffJCRGAY8/70t+hyEyvqqV7YKm502VPu0+Ji30oefrTn2al7LXkITz7CK6I4eYXWRhN6NaIUi65F1OA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.0.tgz",
+      "integrity": "sha512-7BueMuWYg/KBA2EX9zsQ+3OAleEyrJcB+SV5Al/9pLjMQq5mXB/8M5HaUPqZwN812g5kLzj9j43VThlZgWq0hg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.40.1",
-        "@algolia/requester-browser-xhr": "5.40.1",
-        "@algolia/requester-fetch": "5.40.1",
-        "@algolia/requester-node-http": "5.40.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.40.1.tgz",
-      "integrity": "sha512-gWfQuQUBtzUboJv/apVGZMoxSaB0M4Imwl1c9Ap+HpCW7V0KhjBddqF2QQt5tJZCOFsfNIgBbZDGsEPaeKUosw==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.0.tgz",
+      "integrity": "sha512-pJZIyhvUrs+B7c5Lw0iP5yP/NsqJMda7pKRYbfG4KtfGIVSMcAalZhdqL5UX8Z9DOC4KxO9tKV5RDeVjZU0VfQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.40.1.tgz",
-      "integrity": "sha512-RTLjST/t+lsLMouQ4zeLJq2Ss+UNkLGyNVu+yWHanx6kQ3LT5jv8UvPwyht9s7R6jCPnlSI77WnL80J32ZuyJg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.0.tgz",
+      "integrity": "sha512-RydkKDhx0GWTYuw0ndTXHGM8hD8hgwftKE65FfnJZb5bPc9CevOqv3qNPUQiviAwkqT9hQNH31uDGeV3yZkgfA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.40.1",
-        "@algolia/requester-browser-xhr": "5.40.1",
-        "@algolia/requester-fetch": "5.40.1",
-        "@algolia/requester-node-http": "5.40.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.40.1.tgz",
-      "integrity": "sha512-2FEK6bUomBzEYkTKzD0iRs7Ljtjb45rKK/VSkyHqeJnG+77qx557IeSO0qVFE3SfzapNcoytTofnZum0BQ6r3Q==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.0.tgz",
+      "integrity": "sha512-XiS7gdFq/COWiwdWXZ8+RHuewfEo03TkGESk44zU8zTc/Z6R8fm4DNmV52swJKkeB2N9iC7NKpgpM22OOkcgTw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.40.1",
-        "@algolia/requester-browser-xhr": "5.40.1",
-        "@algolia/requester-fetch": "5.40.1",
-        "@algolia/requester-node-http": "5.40.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.40.1.tgz",
-      "integrity": "sha512-Nju4NtxAvXjrV2hHZNLKVJLXjOlW6jAXHef/CwNzk1b2qIrCWDO589ELi5ZHH1uiWYoYyBXDQTtHmhaOVVoyXg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.0.tgz",
+      "integrity": "sha512-LBEJ/q+hn1nJ0aYg5IcWgLNCPjWHTahWmpHNx1qUZMho+9CyWM6LaEnhac45UHjQm/j0m374HP685VrpL133lA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.40.1",
-        "@algolia/requester-browser-xhr": "5.40.1",
-        "@algolia/requester-fetch": "5.40.1",
-        "@algolia/requester-node-http": "5.40.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.40.1.tgz",
-      "integrity": "sha512-Mw6pAUF121MfngQtcUb5quZVqMC68pSYYjCRZkSITC085S3zdk+h/g7i6FxnVdbSU6OztxikSDMh1r7Z+4iPlA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.0.tgz",
+      "integrity": "sha512-2/9jUXKH4IcdU5qxH6cbDH46ZBe46G7xr+MrcHwgEXZcUfdAvUgLSH53MAWuMgxvw0G5yoqiWMifHc62Os0fiQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.40.1",
-        "@algolia/requester-browser-xhr": "5.40.1",
-        "@algolia/requester-fetch": "5.40.1",
-        "@algolia/requester-node-http": "5.40.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -254,93 +185,93 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.40.1.tgz",
-      "integrity": "sha512-z+BPlhs45VURKJIxsR99NNBWpUEEqIgwt10v/fATlNxc4UlXvALdOsWzaFfe89/lbP5Bu4+mbO59nqBC87ZM/g==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.0.tgz",
+      "integrity": "sha512-80tKsQgxXWo+jK0v4YGCHqyTEXawhAKYyr3kOdN51ElfRqUFjZNPVhZk6vRiqSqXfvrH85ytacT3cbJR6+qolA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.40.1",
-        "@algolia/requester-browser-xhr": "5.40.1",
-        "@algolia/requester-fetch": "5.40.1",
-        "@algolia/requester-node-http": "5.40.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.40.1.tgz",
-      "integrity": "sha512-VJMUMbO0wD8Rd2VVV/nlFtLJsOAQvjnVNGkMkspFiFhpBA7s/xJOb+fJvvqwKFUjbKTUA7DjiSi1ljSMYBasXg==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.0.tgz",
+      "integrity": "sha512-4UjmAL8ywGW4rCfK6Qmgw3wIjbrO2wl2s4Eq56JTiN40L2t0XTv0HZkYAmr6nfeiXO0he/2crvZRX6SATSepag==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.40.1",
-        "@algolia/requester-browser-xhr": "5.40.1",
-        "@algolia/requester-fetch": "5.40.1",
-        "@algolia/requester-node-http": "5.40.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.40.1.tgz",
-      "integrity": "sha512-ehvJLadKVwTp9Scg9NfzVSlBKH34KoWOQNTaN8i1Ac64AnO6iH2apJVSP6GOxssaghZ/s8mFQsDH3QIZoluFHA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.0.tgz",
+      "integrity": "sha512-LMpJPtIkfDsHIx5Ga+baNr22ntYbY+e2wT7MSIc/FjAnu9wnBFhx1H/GfhmP/c5/IvbThDX+3ilxPRjSfCI8aA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.40.1",
-        "@algolia/requester-browser-xhr": "5.40.1",
-        "@algolia/requester-fetch": "5.40.1",
-        "@algolia/requester-node-http": "5.40.1"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.40.1.tgz",
-      "integrity": "sha512-PbidVsPurUSQIr6X9/7s34mgOMdJnn0i6p+N6Ab+lsNhY5eiu+S33kZEpZwkITYBCIbhzDLOvb7xZD3gDi+USA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.0.tgz",
+      "integrity": "sha512-tDymJ7nFOAoUuecma3usK6o94dp8m4HYFDGh4ByYQXWkv14cpmDn+nWdylmcZO0Qvco107vqDo4+Anksnl8w1Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.40.1"
+        "@algolia/client-common": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.40.1.tgz",
-      "integrity": "sha512-ThZ5j6uOZCF11fMw9IBkhigjOYdXGXQpj6h4k+T9UkZrF2RlKcPynFzDeRgaLdpYk8Yn3/MnFbwUmib7yxj5Lw==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.0.tgz",
+      "integrity": "sha512-6IDSB5o5dkDPQ4LdOW0Yuw/qy5MdWlO2xDHgPVZgW4YDjbxvnX5PAiV7/WWZdWyVObScZZnnHpPbiqfYs/zBLg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.40.1"
+        "@algolia/client-common": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.40.1.tgz",
-      "integrity": "sha512-H1gYPojO6krWHnUXu/T44DrEun/Wl95PJzMXRcM/szstNQczSbwq6wIFJPI9nyE95tarZfUNU3rgorT+wZ6iCQ==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.0.tgz",
+      "integrity": "sha512-Yyyne4l//vDSdg4MhYJkaVne+KEPi833eCj3/T/87ernTwrvP6j9biXXZELsN8sLI/f2ndV/vugDIy2jdJQB6g==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.40.1"
+        "@algolia/client-common": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -397,13 +328,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -522,9 +453,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -544,13 +475,13 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -586,9 +517,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -642,18 +573,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -696,12 +627,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.4"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1636,13 +1567,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.3.tgz",
-      "integrity": "sha512-Y6ab1kGqZ0u42Zv/4a7l0l72n9DKP/MKoKWaUSBylrhNZO2prYuqFOLbn5aW5SIFXwSH93yfjbgllL8lxuGKLg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.29.7.tgz",
+      "integrity": "sha512-xmAscdE/AsqRW7vutbPNoUmu/nF5SrLKPs7aoJgEjo35lLKA/Bc0i2rMv/hr1+Y0o1bQCiVtith3u2vdgRL39Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
         "babel-plugin-polyfill-corejs2": "^0.4.14",
         "babel-plugin-polyfill-corejs3": "^0.13.0",
         "babel-plugin-polyfill-regenerator": "^0.6.5",
@@ -1977,44 +1908,32 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.4.tgz",
-      "integrity": "sha512-h7iEYiW4HebClDEhtvFObtPmIvrd1SSfpI9EhOeKk4CtIK/ngBWFpuhCzhdmRKtg71ylcue+9I6dv54XYO1epQ==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js-pure": "^3.43.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
-      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.4",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -2022,13 +1941,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2278,9 +2197,9 @@
       }
     },
     "node_modules/@csstools/postcss-cascade-layers/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -2699,9 +2618,9 @@
       }
     },
     "node_modules/@csstools/postcss-is-pseudo-class/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -2938,9 +2857,9 @@
       }
     },
     "node_modules/@csstools/postcss-normalize-display-values": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.0.tgz",
-      "integrity": "sha512-HlEoG0IDRoHXzXnkV4in47dzsxdsjdz6+j7MLjaACABX2NfvjFS6XVAnpaDyGesz9gK2SC7MbNwdCHusObKJ9Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.1.tgz",
+      "integrity": "sha512-TQUGBuRvxdc7TgNSTevYqrL8oItxiwPDixk20qCB5me/W8uF7BPbhRrAvFuhEoywQp/woRsUZ6SJ+sU5idZAIA==",
       "funding": [
         {
           "type": "github",
@@ -2991,6 +2910,28 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/@csstools/postcss-position-area-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-position-area-property/-/postcss-position-area-property-1.0.0.tgz",
+      "integrity": "sha512-fUP6KR8qV2NuUZV3Cw8itx0Ep90aRjAZxAEzC3vrl6yjFv+pFsQbR18UuQctEKmA72K9O27CoYiKEgXxkqjg8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
     "node_modules/@csstools/postcss-progressive-custom-properties": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-4.2.1.tgz",
@@ -3008,6 +2949,32 @@
       "license": "MIT-0",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-property-rule-prelude-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-property-rule-prelude-list/-/postcss-property-rule-prelude-list-1.0.0.tgz",
+      "integrity": "sha512-IxuQjUXq19fobgmSSvUDO7fVwijDJaZMvWQugxfEUxmjBeDCVaDuMpsZ31MsTm5xbnhA+ElDi0+rQ7sQQGisFA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       },
       "engines": {
         "node": ">=18"
@@ -3098,9 +3065,9 @@
       }
     },
     "node_modules/@csstools/postcss-scope-pseudo-class/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -3154,6 +3121,57 @@
       "license": "MIT-0",
       "dependencies": {
         "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-syntax-descriptor-syntax-production": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-syntax-descriptor-syntax-production/-/postcss-syntax-descriptor-syntax-production-1.0.1.tgz",
+      "integrity": "sha512-GneqQWefjM//f4hJ/Kbox0C6f2T7+pi4/fqTqOFGTL3EjnvOReTqO1qUQ30CaUjkwjYq9qZ41hzarrAxCc4gow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-system-ui-font-family": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-system-ui-font-family/-/postcss-system-ui-font-family-1.0.0.tgz",
+      "integrity": "sha512-s3xdBvfWYfoPSBsikDXbuorcMG1nN1M6GdU0qBsGfcmNR0A/qhloQZpTxjA3Xsyrk1VJvwb2pOfiOT3at/DuIQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4"
       },
@@ -3270,25 +3288,43 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@docsearch/core": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.3.tgz",
+      "integrity": "sha512-rUOujwIpxJRgD7+kicVsI3D5sqBvdiRTquzWBpTEXZs8ZXfGbfzpus5HqumaNYTppN2HvH8E2yNuRwYdHJeOlA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 20.0.0",
+        "react": ">= 16.8.0 < 20.0.0",
+        "react-dom": ">= 16.8.0 < 20.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@docsearch/css": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.2.0.tgz",
-      "integrity": "sha512-65KU9Fw5fGsPPPlgIghonMcndyx1bszzrDQYLfierN+Ha29yotMHzVS94bPkZS6On9LS8dE4qmW4P/fGjtCf/g==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.3.tgz",
+      "integrity": "sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==",
       "license": "MIT"
     },
     "node_modules/@docsearch/react": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.2.0.tgz",
-      "integrity": "sha512-zSN/KblmtBcerf7Z87yuKIHZQmxuXvYc6/m0+qnjyNu+Ir67AVOagTa1zBqcxkVUVkmBqUExdcyrdo9hbGbqTw==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.3.tgz",
+      "integrity": "sha512-Bg2wdDsoQVlNCcEKuEJAU04tvHCqgx8rIu+uIoM4pRtcx3TBKJuXutJik3LTA8LRc9YEyHkrYUrmcC0D7BYf+g==",
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/react": "^2.0.30",
         "@algolia/autocomplete-core": "1.19.2",
-        "@docsearch/css": "4.2.0",
-        "ai": "^5.0.30",
-        "algoliasearch": "^5.28.0",
-        "marked": "^16.3.0",
-        "zod": "^4.1.8"
+        "@docsearch/core": "4.6.3",
+        "@docsearch/css": "4.6.3"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3311,10 +3347,42 @@
         }
       }
     },
+    "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-core": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
+      "integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
+        "@algolia/autocomplete-shared": "1.19.2"
+      }
+    },
+    "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
+      "integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.19.2"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-shared": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
+      "integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
     "node_modules/@docusaurus/babel": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.9.0.tgz",
-      "integrity": "sha512-QcZ+Rey0OvlLK9SPN4/+VWL+ut/tuADVdunA1fmC96fytdYjatdJrcw1koYdp/c+3k6lVYlwg9DDVNDecyLCAA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.1.tgz",
+      "integrity": "sha512-DZzFO1K3v/GoEt1fx1DiYHF4en+PuhtQf1AkQJa5zu3CoeKSpr5cpQRUlz3jr0m44wyzmSXu9bVpfir+N4+8bg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
@@ -3325,10 +3393,9 @@
         "@babel/preset-react": "^7.25.9",
         "@babel/preset-typescript": "^7.25.9",
         "@babel/runtime": "^7.25.9",
-        "@babel/runtime-corejs3": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -3338,17 +3405,17 @@
       }
     },
     "node_modules/@docusaurus/bundler": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.9.0.tgz",
-      "integrity": "sha512-HaRLSmiwnJQ3uHBV3rd/BRDM9S/nHAshRk54djRZ+RX9ze4ONuFAovdD5es20ZDj7PRTjo38GVnBtHvuL/SwsQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.1.tgz",
+      "integrity": "sha512-HIqQPvbqnnQRe4NsBd1774KRarjXqS6wHsWELtyuSs1gCfvixJO2jUGH/OEBtr1Gvzpw+ze5CjGMvSJ8UE1KUw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.9.0",
-        "@docusaurus/cssnano-preset": "3.9.0",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
+        "@docusaurus/babel": "3.10.1",
+        "@docusaurus/cssnano-preset": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
         "babel-loader": "^9.2.1",
         "clean-css": "^5.3.3",
         "copy-webpack-plugin": "^11.0.0",
@@ -3366,7 +3433,7 @@
         "tslib": "^2.6.0",
         "url-loader": "^4.1.1",
         "webpack": "^5.95.0",
-        "webpackbar": "^6.0.1"
+        "webpackbar": "^7.0.0"
       },
       "engines": {
         "node": ">=20.0"
@@ -3381,18 +3448,18 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.0.tgz",
-      "integrity": "sha512-sEJ4MW/zuh1MfPORCRbSwnW/PjsVmOigWwBU6clcxm221/CNdnI/XqgfBrl2jj/zocSdNoQM8E3IP2W8dygi6g==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.1.tgz",
+      "integrity": "sha512-3pf2fXXw0eVk8WnC3T4LIigRDupcpvngpKo9Vy7mYyBhuddc0klDUuZAIfzMoK6z05pdlk6EFC/vBSX43+1O5w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.9.0",
-        "@docusaurus/bundler": "3.9.0",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/mdx-loader": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/babel": "3.10.1",
+        "@docusaurus/bundler": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -3404,7 +3471,7 @@
         "escape-html": "^1.0.3",
         "eta": "^2.2.0",
         "eval": "^0.1.8",
-        "execa": "5.1.1",
+        "execa": "^5.1.1",
         "fs-extra": "^11.1.1",
         "html-tags": "^3.3.1",
         "html-webpack-plugin": "^5.6.0",
@@ -3415,12 +3482,12 @@
         "prompts": "^2.4.2",
         "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
         "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+        "react-loadable-ssr-addon-v5-slorber": "^1.0.3",
         "react-router": "^5.3.4",
         "react-router-config": "^5.1.1",
         "react-router-dom": "^5.3.4",
         "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
+        "serve-handler": "^6.1.7",
         "tinypool": "^1.0.2",
         "tslib": "^2.6.0",
         "update-notifier": "^6.0.2",
@@ -3436,15 +3503,21 @@
         "node": ">=20.0"
       },
       "peerDependencies": {
+        "@docusaurus/faster": "*",
         "@mdx-js/react": "^3.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@docusaurus/faster": {
+          "optional": true
+        }
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.9.0.tgz",
-      "integrity": "sha512-prCJXUcoJZBlovJzSFkfnfWr1gXd53VZfE+17fIpUWS6Zioc7WE4FPoXPi5ldAGZ8brhXre5xQ8NWDE90XP9yw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.1.tgz",
+      "integrity": "sha512-eNfHGcTKCSq6xmcavAkX3RRclHaE2xRCMParlDXLdXVP01/a2e/jKXMj/0ULnLFQSNwwuI62L0Ge8J+nZsR7UQ==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
@@ -3457,9 +3530,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.9.0.tgz",
-      "integrity": "sha512-lDtThsocWTF8ZrVF01ltfctA/xgtD/3oXWqEkKIDzF4fCWsWXH7hC4LCqT23xSuxZTIo8N+y02XSPvA/8DLInw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.1.tgz",
+      "integrity": "sha512-oPjNFnfJsRCkePVjkGrxWGq4MvJKRQT0r9jOP0eRBTZ7Wr9FAbzdP/Gjs0I2Ss6YRkPoEgygKG112OkE6skvJw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -3470,14 +3543,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.0.tgz",
-      "integrity": "sha512-9bfJYdkZFE+REwevkT4CYdTJ2f6ydgkbUFylkzTXrNGtBXtx25TRJGdn2cVzm3eVkeWdJrGkG/ypwrIWnbu5UA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.1.tgz",
+      "integrity": "sha512-GRmeb/wQ+iXRrFwcHBfgQhrJxGElgCsoTWZYDhccjsZVne1p8MK/EpQVIloXttz76TCe78kKD5AEG9n1xc1oxQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -3509,13 +3582,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
-      "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
-      "dev": true,
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz",
+      "integrity": "sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.9.2",
+        "@docusaurus/types": "3.10.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -3528,59 +3600,22 @@
         "react-dom": "*"
       }
     },
-    "node_modules/@docusaurus/module-type-aliases/node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/module-type-aliases/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.9.0.tgz",
-      "integrity": "sha512-XZXJ/rQgi2jT0XWNXOnSKooJgtGHPzkjaBjww6K9PD+YevNMTP9U8Y5sA7cLA5Bwuqrpee4i8NO3tSrjhhDW5w==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.1.tgz",
+      "integrity": "sha512-mmkgE6Q2+K74tnkou7tXlpDLvoCU/qkSa2GSQ3XUiHWvcebCoDQzS670RR3tO8PmaWlIyWWISYWzZLuMfxunRA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/mdx-loader": "3.9.0",
-        "@docusaurus/theme-common": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "cheerio": "1.0.0-rc.12",
+        "combine-promises": "^1.1.0",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -3601,20 +3636,20 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.0.tgz",
-      "integrity": "sha512-PP+iDJg+lj4cn/7GbbmiguaQ8OX08YxnzQ17KqRC4ufJm11jdyXD33wA7vVtbeG/BkkgkiB/K7YyPHCPwmfVhg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
+      "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/mdx-loader": "3.9.0",
-        "@docusaurus/module-type-aliases": "3.9.0",
-        "@docusaurus/theme-common": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/module-type-aliases": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -3633,36 +3668,17 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.0.tgz",
-      "integrity": "sha512-0ucYr79FpTCebN+l3ZlKqoW7HbMqSKT8JdsEg6QoUtxD3C7trF6KZiK/X6Yh+xekO1w3zzXYgPcIYTF2DV81tQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.9.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.9.0.tgz",
-      "integrity": "sha512-ngetCpAZuivlaHC0l8a5KoK6PQWGuZ8742VwK7dbXeIW0Y70P4xwuocBdsCIQ9J6nB9rlTXRYMpNVyYyCpD7/Q==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.1.tgz",
+      "integrity": "sha512-huJpaRPMl42nsFwuCXvV8bVDj2MazuwRJIUylI/RSlmZeJssVoZXeCjVf1y+1Drtpa9SKcdGn8yoJ76IRJijtw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/mdx-loader": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -3676,15 +3692,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-css-cascade-layers": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.9.0.tgz",
-      "integrity": "sha512-giPTCjEzeaamMn8EHY/oDvsPDxF5ei1/q5lPUFQLldbc65jFQ1k6pPwKjtOznYy3TSfClCF1F1DNpYWIx7B5LA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.1.tgz",
+      "integrity": "sha512-r//fn+MNHkE1wCof8T29VAQezt1enGCpsFxoziBbvLgBM4JfXN2P3rxrBaavHmvLvm7lYkpJeitcDthwnmWCTw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3692,14 +3708,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.9.0.tgz",
-      "integrity": "sha512-DuFOZya+bcrYiL54qBEn2rdKuoWWNyOV5IoHI2MURLzwuYaKu/J9Gi618XUsj3N3qvqG2uxWQiXZcs9ecfMadA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.10.1.tgz",
+      "integrity": "sha512-9KqOpKNfAyqGZykRb9LhIT/vyRF6sm/ykhjj/39JvaJahDS+jZJE0Z1Wfz9q3DUNDTMNN0Q7u/kk4rKKU+IJuA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^2.3.0",
         "tslib": "^2.6.0"
@@ -3713,14 +3729,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.9.0.tgz",
-      "integrity": "sha512-mUXvpasTDR2pXdnkkhGxEgB9frVAvLGc+T3fp6SGT2F+YoEQtjcmz9D43zubQawLn+W1KEhoj+vPusYe+HAl+A==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.1.tgz",
+      "integrity": "sha512-8o0P1KtmgdYQHH+oInitPpRWI0Of5XednAX4+DMhQNSmGSRNrsEEHg1ebv35m9AgRClfAytCJ5jA9KvcASTyuA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3732,15 +3748,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.9.0.tgz",
-      "integrity": "sha512-L4tCKYnmcyLV6VQs7XWQ3r7YSllagAU2GylZzdvz7NRMcXE12uSW5MCC2aSltbk09MYlqrYv1Ntp+ESsMvptYw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.1.tgz",
+      "integrity": "sha512-pu3xIUo5o/zCMLfUY9BO5KOwSH0zIsAGyFRPvXHayFSA5XIhCU/SFuB0g0ZNjFn9niZLCaNvoeAuOGFJZq0fdw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
-        "@types/gtag.js": "^0.0.12",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "@types/gtag.js": "^0.0.20",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3752,14 +3768,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.9.0.tgz",
-      "integrity": "sha512-+jWO3tkrvsMUKQ69KTIj9ZBf8sKY5kodLcP4yIaEkPzfWq9IEpE+ekQCtFWlrAmkJUtSxbjHK6HNZZkUNwwq7w==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.1.tgz",
+      "integrity": "sha512-f6fyGHiCm7kJHBtAisGQS5oNBnpnMTYQZxDXeVrnw/3zWU+LMA22pr6UHGYkBKDbN+qPC5QHG3NuOfzQLq3+Lw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3771,17 +3787,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.9.0.tgz",
-      "integrity": "sha512-QOyLooWuF+On4q2RDGVZtKY0tlfdZwD9e/p7g1sJLUfOwN518V2Bo+kZtU82Or42SCKjyJ0lhSqAUOZfbeFhFw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.1.tgz",
+      "integrity": "sha512-C26MbmmqgdjkDq1htaZ3aD7LzEDKFWXfpyQpt0EOUThuq5nV77zDaedV20yHcVo9p+3ey9aZ4pbHA0D3QcZTzg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -3795,15 +3811,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-svgr": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.9.0.tgz",
-      "integrity": "sha512-pUZIfnhFtAYDmDwimFiBY+sxNUigyJnKbCwI9pTiXr3uGp43CsSsN8gwl/i8jBmqfsZzvNnGZNxc75wy9v6RXA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.1.tgz",
+      "integrity": "sha512-6SFxsmjWFkVLDmBUvFK6i72QjUwqyQFe4Ovz+SUJophJjOyVG3ZZG5IQpBC/kX/Gfv1yWeU9nWauH6F6Q7QX/Q==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "@svgr/core": "8.1.0",
         "@svgr/webpack": "^8.1.0",
         "tslib": "^2.6.0",
@@ -3901,26 +3917,26 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.9.0.tgz",
-      "integrity": "sha512-nLoiDxf8bDNNxDSZ28+pFfSfT+QRi08Pn2K0zIvbjkM/X/otMs4ho0K8+2FpoLOoGApifaSuNfJXpGYnQV3rGA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.10.1.tgz",
+      "integrity": "sha512-YO/FL8v1zmbxoTso6mjMz/RDjhaTJxb1UpFFTDdY5847LLDCeyYiYlrhyTbgN1RIN3xnkLKZ9Lj1x8hUzI4JOg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/plugin-content-blog": "3.9.0",
-        "@docusaurus/plugin-content-docs": "3.9.0",
-        "@docusaurus/plugin-content-pages": "3.9.0",
-        "@docusaurus/plugin-css-cascade-layers": "3.9.0",
-        "@docusaurus/plugin-debug": "3.9.0",
-        "@docusaurus/plugin-google-analytics": "3.9.0",
-        "@docusaurus/plugin-google-gtag": "3.9.0",
-        "@docusaurus/plugin-google-tag-manager": "3.9.0",
-        "@docusaurus/plugin-sitemap": "3.9.0",
-        "@docusaurus/plugin-svgr": "3.9.0",
-        "@docusaurus/theme-classic": "3.9.0",
-        "@docusaurus/theme-common": "3.9.0",
-        "@docusaurus/theme-search-algolia": "3.9.0",
-        "@docusaurus/types": "3.9.0"
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/plugin-content-blog": "3.10.1",
+        "@docusaurus/plugin-content-docs": "3.10.1",
+        "@docusaurus/plugin-content-pages": "3.10.1",
+        "@docusaurus/plugin-css-cascade-layers": "3.10.1",
+        "@docusaurus/plugin-debug": "3.10.1",
+        "@docusaurus/plugin-google-analytics": "3.10.1",
+        "@docusaurus/plugin-google-gtag": "3.10.1",
+        "@docusaurus/plugin-google-tag-manager": "3.10.1",
+        "@docusaurus/plugin-sitemap": "3.10.1",
+        "@docusaurus/plugin-svgr": "3.10.1",
+        "@docusaurus/theme-classic": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/theme-search-algolia": "3.10.1",
+        "@docusaurus/types": "3.10.1"
       },
       "engines": {
         "node": ">=20.0"
@@ -3931,26 +3947,27 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.9.0.tgz",
-      "integrity": "sha512-RToUIabJOyX41nMIxkFn8LPeA+uHgySzyd6Ak/gsINqWHHTLDMoYPxBUmNm3S+okcfuMI54kNYvD6TY+6TIYDA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.1.tgz",
+      "integrity": "sha512-VU1RK0qb2pab0si4r7HFK37cYco8VzqLj3u1PspVipSr/z/GPVKHO4/HXbnePqHoWDk8urjyGSeatH0NIMBM1A==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/mdx-loader": "3.9.0",
-        "@docusaurus/module-type-aliases": "3.9.0",
-        "@docusaurus/plugin-content-blog": "3.9.0",
-        "@docusaurus/plugin-content-docs": "3.9.0",
-        "@docusaurus/plugin-content-pages": "3.9.0",
-        "@docusaurus/theme-common": "3.9.0",
-        "@docusaurus/theme-translations": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/module-type-aliases": "3.10.1",
+        "@docusaurus/plugin-content-blog": "3.10.1",
+        "@docusaurus/plugin-content-docs": "3.10.1",
+        "@docusaurus/plugin-content-pages": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/theme-translations": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
+        "copy-text-to-clipboard": "^3.2.0",
         "infima": "0.2.0-alpha.45",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
@@ -3970,25 +3987,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.0.tgz",
-      "integrity": "sha512-0ucYr79FpTCebN+l3ZlKqoW7HbMqSKT8JdsEg6QoUtxD3C7trF6KZiK/X6Yh+xekO1w3zzXYgPcIYTF2DV81tQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.9.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
     "node_modules/@docusaurus/theme-classic/node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -3999,15 +3997,15 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.0.tgz",
-      "integrity": "sha512-pqNoQgttIpk7Ndm6N8OGbhi+1wBIQXQPYM7bPf1HDraXfvVpOzhcDty1yyK4coPWl0M7NxednZvKw4atfQ70Ew==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
+      "integrity": "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.9.0",
-        "@docusaurus/module-type-aliases": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/module-type-aliases": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -4026,25 +4024,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.0.tgz",
-      "integrity": "sha512-0ucYr79FpTCebN+l3ZlKqoW7HbMqSKT8JdsEg6QoUtxD3C7trF6KZiK/X6Yh+xekO1w3zzXYgPcIYTF2DV81tQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.9.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
     "node_modules/@docusaurus/theme-common/node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -4055,19 +4034,20 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.9.0.tgz",
-      "integrity": "sha512-nbY7ZJVA10kTiBLJtscxK1aECeYvYFz+Sno9PkCE9KeFXqRDr6omtNmLVkbvyl4b6xgz+6yOIBdO/idLPVDpWg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.1.tgz",
+      "integrity": "sha512-OTaARARVZj2GvkJQjB+1jOIxntRaXea+G+fMsNqrZBAU1O1vJKDW22R7kECOHW27oJCLFN9HKaZeRrfAUyviug==",
       "license": "MIT",
       "dependencies": {
-        "@docsearch/react": "^3.9.0 || ^4.1.0",
-        "@docusaurus/core": "3.9.0",
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/plugin-content-docs": "3.9.0",
-        "@docusaurus/theme-common": "3.9.0",
-        "@docusaurus/theme-translations": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-validation": "3.9.0",
+        "@algolia/autocomplete-core": "^1.19.2",
+        "@docsearch/react": "^3.9.0 || ^4.3.2",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/plugin-content-docs": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/theme-translations": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "algoliasearch": "^5.37.0",
         "algoliasearch-helper": "^3.26.0",
         "clsx": "^2.0.0",
@@ -4095,9 +4075,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.9.0.tgz",
-      "integrity": "sha512-4HUELBsE+rhtlnR1MsaNB9nJXPFZANeDQa5If1GfFVlis5mWUfdmXmbGangR7PfpK2tc56UETMtzjKrX5L5UWw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.1.tgz",
+      "integrity": "sha512-cLMyaKivjBVWKMJuWqyFVVgtqe8DPJNPkog0bn8W1MDVAKcPdxRFycBfC1We1RaNp7Rdk513bmtW78RR6OBxBw==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -4108,16 +4088,16 @@
       }
     },
     "node_modules/@docusaurus/tsconfig": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.9.2.tgz",
-      "integrity": "sha512-j6/Fp4Rlpxsc632cnRnl5HpOWeb6ZKssDj6/XzzAzVGXXfm9Eptx3rxCC+fDzySn9fHTS+CWJjPineCR1bB5WQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.10.1.tgz",
+      "integrity": "sha512-rYvB7yqkdqWIpAbDzQljGfM4cDBkLTbhmagZBEcsyj6oPUsz47lmW2pYdN1j+7sGFgltbAmQH62xfbrij4Eh6Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.0.tgz",
-      "integrity": "sha512-0klJLhHFHqkYoxIVp1LD7dnU1ASRTfSX+HFDiELOdz+YQUkOSfuU5hDa46zD8bLxrYffCb8FtJI7Z6BWAmVodg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -4151,16 +4131,16 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.9.0.tgz",
-      "integrity": "sha512-wpVRQbDhXxqbb1llhkpu++aD4UdHHQ5M7J8DmJELDphlwmpI44TdS5elQZOsjzPfGyITZyQLekcDXjyteJ0/bw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.1.tgz",
+      "integrity": "sha512-3ojeJry9xBYdJO6qoyyzqeJFSJBVx2mXhyDzSdjwL2+URFQMf+h25gG38iswGImicK0ELjTd1EL2xzk8hf3QPw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/types": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
         "escape-string-regexp": "^4.0.0",
-        "execa": "5.1.1",
+        "execa": "^5.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
         "github-slugger": "^1.5.0",
@@ -4183,12 +4163,12 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.9.0.tgz",
-      "integrity": "sha512-zpmzRn2mniMnrx8ZEYyyDsr0/7EksVgUXL9IuODp0DSK+R19nDGCY7w2NaMGRmGnrQQKsT3t0NDZzBk0V6N9Iw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.1.tgz",
+      "integrity": "sha512-5mFSgEADtnFxFH7RLw02QA5MpU5JVUCj0MPeIvi/aF4Fi45tQRIuTwXoXDqJ+1VfQJuYJGz3SI63wmGz4HvXzA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.9.0",
+        "@docusaurus/types": "3.10.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -4196,14 +4176,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.9.0.tgz",
-      "integrity": "sha512-xpVLdFPpsE5dYuE7hOtghccCrRWRhM6tUQ4YpfSy5snCDWgROITG5Mj22fGstd/HBqTzKD8NFs7qPPs42qjgWg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.1.tgz",
+      "integrity": "sha512-cRv1X69jwaWv47waglllgZVWzeBFLhl53XT/XED/83BerVBTC5FTP8WTcVl8Z6sZOegDSwitu/wpCSPCDOT6lg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.9.0",
-        "@docusaurus/utils": "3.9.0",
-        "@docusaurus/utils-common": "3.9.0",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -4603,15 +4583,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -5023,9 +4994,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
@@ -5050,12 +5021,6 @@
         "micromark-util-character": "^1.1.0",
         "micromark-util-symbol": "^1.0.1"
       }
-    },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
-      "license": "MIT"
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -5757,9 +5722,9 @@
       }
     },
     "node_modules/@types/gtag.js": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.12.tgz",
-      "integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.20.tgz",
+      "integrity": "sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==",
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -6041,9 +6006,9 @@
       }
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.33",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
-      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -6060,15 +6025,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
-    },
-    "node_modules/@vercel/oidc": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.3.tgz",
-      "integrity": "sha512-yNEQvPcVrK9sIe637+I0jD6leluPxzwJKx/Haw6F4H77CdDsszUn5V3o96LPziXkSNE2B83+Z3mjqGKBK/R6Gg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 20"
-      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -6317,24 +6273,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ai": {
-      "version": "5.0.76",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.76.tgz",
-      "integrity": "sha512-ZCxi1vrpyCUnDbtYrO/W8GLvyacV9689f00yshTIQ3mFFphbD7eIv40a2AOZBv3GGRA7SSRYIDnr56wcS/gyQg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/gateway": "2.0.0",
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.12",
-        "@opentelemetry/api": "1.9.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
     "node_modules/ajv": {
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
@@ -6395,34 +6333,34 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.40.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.40.1.tgz",
-      "integrity": "sha512-iUNxcXUNg9085TJx0HJLjqtDE0r1RZ0GOGrt8KNQqQT5ugu8lZsHuMUYW/e0lHhq6xBvmktU9Bw4CXP9VQeKrg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.0.tgz",
+      "integrity": "sha512-af+rI+tUVeS9KWHPAZQHIHPOIC3StPRR6IwQu2nz1aQoTL6Gs5Ty3KsHCgbXMHOpoh9QqSjq8F3KJ8xmaCZSBA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.6.1",
-        "@algolia/client-abtesting": "5.40.1",
-        "@algolia/client-analytics": "5.40.1",
-        "@algolia/client-common": "5.40.1",
-        "@algolia/client-insights": "5.40.1",
-        "@algolia/client-personalization": "5.40.1",
-        "@algolia/client-query-suggestions": "5.40.1",
-        "@algolia/client-search": "5.40.1",
-        "@algolia/ingestion": "1.40.1",
-        "@algolia/monitoring": "1.40.1",
-        "@algolia/recommend": "5.40.1",
-        "@algolia/requester-browser-xhr": "5.40.1",
-        "@algolia/requester-fetch": "5.40.1",
-        "@algolia/requester-node-http": "5.40.1"
+        "@algolia/abtesting": "1.21.0",
+        "@algolia/client-abtesting": "5.55.0",
+        "@algolia/client-analytics": "5.55.0",
+        "@algolia/client-common": "5.55.0",
+        "@algolia/client-insights": "5.55.0",
+        "@algolia/client-personalization": "5.55.0",
+        "@algolia/client-query-suggestions": "5.55.0",
+        "@algolia/client-search": "5.55.0",
+        "@algolia/ingestion": "1.55.0",
+        "@algolia/monitoring": "1.55.0",
+        "@algolia/recommend": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.26.0.tgz",
-      "integrity": "sha512-Rv2x3GXleQ3ygwhkhJubhhYGsICmShLAiqtUuJTUkr9uOCOXyF2E71LVT4XDnVffbknv8XgScP4U0Oxtgm+hIw==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.1.tgz",
+      "integrity": "sha512-6ck2YFudF2Pje7szQoPBiRFTGfd+1I+0I/WfLPGn0bj1kvrFoOQmNyedNiDxTk3/r4IfSLDYk+RA4G7u8H6+yA==",
       "license": "MIT",
       "dependencies": {
         "@algolia/events": "^4.0.1"
@@ -6481,33 +6419,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
@@ -6545,6 +6456,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
+      "integrity": "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/anymatch": {
@@ -6615,9 +6535,9 @@
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.21",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
       "funding": [
         {
           "type": "opencollective",
@@ -6634,10 +6554,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.24.4",
-        "caniuse-lite": "^1.0.30001702",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
       },
@@ -6649,6 +6568,39 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/autoprefixer/node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/babel-loader": {
@@ -6762,9 +6714,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.8",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
-      "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -7079,14 +7031,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -7175,9 +7127,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001780",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001780.tgz",
-      "integrity": "sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7831,6 +7783,18 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "license": "MIT"
     },
+    "node_modules/copy-text-to-clipboard": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.2.tgz",
+      "integrity": "sha512-T6SqyLd1iLuqPA90J5N4cTalrtovCySh58iiZDGJ6FGznbclKh4UI+FGacQSgFzwKG77W7XT5gwbVEbd9cIH1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/copy-webpack-plugin": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
@@ -7917,17 +7881,6 @@
       "dependencies": {
         "browserslist": "^4.26.3"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/core-js-pure": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.46.0.tgz",
-      "integrity": "sha512-NMCW30bHNofuhwLhYPt66OLOKTMbOhgTTatKVbaQC3KRHpTCiRIBYvtshr+NBYSnBxwAFhjW/RfJ0XbIjS16rw==",
-      "hasInstallScript": true,
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -8038,9 +7991,9 @@
       }
     },
     "node_modules/css-blank-pseudo/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8051,9 +8004,9 @@
       }
     },
     "node_modules/css-declaration-sorter": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.0.tgz",
-      "integrity": "sha512-LQF6N/3vkAMYF4xoHLJfG718HRJh34Z8BnNhd6bosOMIVjMlhuZK5++oZa3uYAgrI5+7x2o27gUqTR2U/KjUOQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.4.0.tgz",
+      "integrity": "sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==",
       "license": "ISC",
       "engines": {
         "node": "^14 || ^16 || >=18"
@@ -8112,9 +8065,9 @@
       }
     },
     "node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8267,9 +8220,9 @@
       }
     },
     "node_modules/cssdb": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.4.2.tgz",
-      "integrity": "sha512-PzjkRkRUS+IHDJohtxkIczlxPPZqRo0nXplsYXOMBRPjcVRjj1W4DfvRgshUYTVuUigU7ptVYkFJQ7abUB0nyg==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.9.0.tgz",
+      "integrity": "sha512-J8jOU/hLjaXcO1LldOLraJSQpfLXRKof0I7mtbRyOy2AAXgqst0x9rlgi2qXeD6d0ou3ZLqcPAMqYVbpCbrxEw==",
       "funding": [
         {
           "type": "opencollective",
@@ -8723,6 +8676,44 @@
         "node": ">=6"
       }
     },
+    "node_modules/docusaurus-plugin-llms": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.4.0.tgz",
+      "integrity": "sha512-jYlj2HJ5+gu7oJZuJ83Hk8KlB65YlZZ/7UpHXiL7Qr+qpNBkVocmt2Molc6F3HNr5RqcfhWD/98CvgyNztg/ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "minimatch": "^9.0.3",
+        "yaml": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rachfop"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/docusaurus-plugin-openapi": {
       "version": "0.7.7",
       "resolved": "https://registry.npmjs.org/docusaurus-plugin-openapi/-/docusaurus-plugin-openapi-0.7.7.tgz",
@@ -8973,9 +8964,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.321",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
-      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
+      "version": "1.5.375",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
+      "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -9396,15 +9387,6 @@
         "node": ">=0.8.x"
       }
     },
-    "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -9627,30 +9609,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/file-loader": {
@@ -9931,15 +9889,15 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
       "license": "MIT",
       "engines": {
         "node": "*"
       },
       "funding": {
-        "type": "patreon",
+        "type": "github",
         "url": "https://github.com/sponsors/rawify"
       }
     },
@@ -11673,12 +11631,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-compare": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
@@ -11971,18 +11923,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/marked": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.1.tgz",
-      "integrity": "sha512-ntROs7RaN3EvWfy3EZi14H4YxmT6A5YvywfhO+0pm+cH/dnSQRmdAmoFIc3B9aiwTehyk7pESH4ofyBY+V5hZg==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -14323,9 +14263,9 @@
       }
     },
     "node_modules/mini-css-extract-plugin": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
-      "integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.2.tgz",
+      "integrity": "sha512-AOSS0IdEB95ayVkxn5oGzNQwqAi2J0Jb/kKm43t7H73s8+f5873g0yuj0PNvK4dO75mu5DHg4nlgp4k6Kga8eg==",
       "license": "MIT",
       "dependencies": {
         "schema-utils": "^4.0.0",
@@ -14418,9 +14358,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
       "funding": [
         {
           "type": "github",
@@ -14562,15 +14502,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/normalize-url": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.0.tgz",
@@ -14634,9 +14565,9 @@
       }
     },
     "node_modules/null-loader/node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -15346,9 +15277,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -15365,7 +15296,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -15399,9 +15330,9 @@
       }
     },
     "node_modules/postcss-attribute-case-insensitive/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -15643,9 +15574,9 @@
       }
     },
     "node_modules/postcss-custom-selectors/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -15681,9 +15612,9 @@
       }
     },
     "node_modules/postcss-dir-pseudo-class/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -15809,9 +15740,9 @@
       }
     },
     "node_modules/postcss-focus-visible/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -15847,9 +15778,9 @@
       }
     },
     "node_modules/postcss-focus-within/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -16136,9 +16067,9 @@
       }
     },
     "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -16164,9 +16095,9 @@
       }
     },
     "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -16263,9 +16194,9 @@
       }
     },
     "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -16506,9 +16437,9 @@
       }
     },
     "node_modules/postcss-preset-env": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.4.0.tgz",
-      "integrity": "sha512-2kqpOthQ6JhxqQq1FSAAZGe9COQv75Aw8WbsOvQVNJ2nSevc9Yx/IKZGuZ7XJ+iOTtVon7LfO7ELRzg8AZ+sdw==",
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.6.1.tgz",
+      "integrity": "sha512-yrk74d9EvY+W7+lO9Aj1QmjWY9q5NsKjK2V9drkOPZB/X6KZ0B3igKsHUYakb7oYVhnioWypQX3xGuePf89f3g==",
       "funding": [
         {
           "type": "github",
@@ -16546,23 +16477,27 @@
         "@csstools/postcss-media-minmax": "^2.0.9",
         "@csstools/postcss-media-queries-aspect-ratio-number-values": "^3.0.5",
         "@csstools/postcss-nested-calc": "^4.0.0",
-        "@csstools/postcss-normalize-display-values": "^4.0.0",
+        "@csstools/postcss-normalize-display-values": "^4.0.1",
         "@csstools/postcss-oklab-function": "^4.0.12",
+        "@csstools/postcss-position-area-property": "^1.0.0",
         "@csstools/postcss-progressive-custom-properties": "^4.2.1",
+        "@csstools/postcss-property-rule-prelude-list": "^1.0.0",
         "@csstools/postcss-random-function": "^2.0.1",
         "@csstools/postcss-relative-color-syntax": "^3.0.12",
         "@csstools/postcss-scope-pseudo-class": "^4.0.1",
         "@csstools/postcss-sign-functions": "^1.1.4",
         "@csstools/postcss-stepped-value-functions": "^4.0.9",
+        "@csstools/postcss-syntax-descriptor-syntax-production": "^1.0.1",
+        "@csstools/postcss-system-ui-font-family": "^1.0.0",
         "@csstools/postcss-text-decoration-shorthand": "^4.0.3",
         "@csstools/postcss-trigonometric-functions": "^4.0.9",
         "@csstools/postcss-unset-value": "^4.0.0",
-        "autoprefixer": "^10.4.21",
-        "browserslist": "^4.26.0",
+        "autoprefixer": "^10.4.23",
+        "browserslist": "^4.28.1",
         "css-blank-pseudo": "^7.0.1",
         "css-has-pseudo": "^7.0.3",
         "css-prefers-color-scheme": "^10.0.0",
-        "cssdb": "^8.4.2",
+        "cssdb": "^8.6.0",
         "postcss-attribute-case-insensitive": "^7.0.1",
         "postcss-clamp": "^4.1.0",
         "postcss-color-functional-notation": "^7.0.12",
@@ -16622,9 +16557,9 @@
       }
     },
     "node_modules/postcss-pseudo-class-any-link/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -16715,9 +16650,9 @@
       }
     },
     "node_modules/postcss-selector-not/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -16728,9 +16663,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -17275,9 +17210,9 @@
       }
     },
     "node_modules/react-loadable-ssr-addon-v5-slorber": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.1.tgz",
-      "integrity": "sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.3.tgz",
+      "integrity": "sha512-GXfh9VLwB5ERaCsU6RULh7tkemeX15aNh6wuMEBtfdyMa7fFG8TXrhXlx1SoEK2Ty/l6XIkzzYIQmyaWW3JgdQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.3"
@@ -17916,15 +17851,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/require-directory": {
@@ -18854,9 +18780,9 @@
       "license": "MIT"
     },
     "node_modules/sitemap": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.2.tgz",
-      "integrity": "sha512-ARCqzHJ0p4gWt+j7NlU5eDlIO9+Rkr/JhPFZKKQ1l5GCus7rJH4UdrlVAh0xC/gDS/Qir2UMxqYNHtsKr2rpCw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.3.tgz",
+      "integrity": "sha512-tAjEd+wt/YwnEbfNB2ht51ybBJxbEWwe5ki/Z//Wh0rpBFTCUSj46GnxUKEWzhfuJTsee8x3lybHxFgUMig2hw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^17.0.5",
@@ -19368,19 +19294,6 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
-    "node_modules/swr": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.6.tgz",
-      "integrity": "sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
@@ -19494,18 +19407,6 @@
       },
       "peerDependencies": {
         "tslib": "^2"
-      }
-    },
-    "node_modules/throttleit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/thunky": {
@@ -20067,15 +19968,6 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "license": "MIT"
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/util": {
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
@@ -20532,96 +20424,30 @@
       }
     },
     "node_modules/webpackbar": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-6.0.1.tgz",
-      "integrity": "sha512-TnErZpmuKdwWBdMoexjio3KKX6ZtoKHRVvLIU0A47R0VVBDtx3ZyOJDktgYixhoJokZTYTt1Z37OkO9pnGJa9Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-7.0.0.tgz",
+      "integrity": "sha512-aS9soqSO2iCHgqHoCrj4LbfGQUboDCYJPSFOAchEK+9psIjNrfSWW4Y0YEz67MKURNvMmfo0ycOg9d/+OOf9/Q==",
       "license": "MIT",
       "dependencies": {
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2",
+        "ansis": "^3.2.0",
         "consola": "^3.2.3",
-        "figures": "^3.2.0",
-        "markdown-table": "^2.0.0",
         "pretty-time": "^1.1.0",
-        "std-env": "^3.7.0",
-        "wrap-ansi": "^7.0.0"
+        "std-env": "^3.7.0"
       },
       "engines": {
         "node": ">=14.21.3"
       },
       "peerDependencies": {
+        "@rspack/core": "*",
         "webpack": "3 || 4 || 5"
-      }
-    },
-    "node_modules/webpackbar/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/webpackbar/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/webpackbar/node_modules/markdown-table": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
-      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
-      "license": "MIT",
-      "dependencies": {
-        "repeat-string": "^1.0.0"
       },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/webpackbar/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/webpackbar/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/webpackbar/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/websocket-driver": {
@@ -20972,24 +20798,15 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
-      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.10.1",
     "@docusaurus/tsconfig": "^3.10.1",
+    "docusaurus-plugin-llms": "^0.4.0",
     "glob": "^10.2.2",
     "simple-git": "^3.17.0",
     "tmp": "^0.2.1",


### PR DESCRIPTION
Add an `llms.txt` file to the site root with all pages for all products, and one for each product (ex. `defradb/llms.txt`).

I haven't been able to find any official resource pointing to those files being useful. All (unofficial) docs I could find state that those files are _crawled_, but not _used_, and that sitemap and usual crawling practices still apply. So while it doesn't hurt to have an extra text file, it doesn't look like it will provide much benefit.