### PR TITLE
Uniform setup and revise all results

### DIFF
--- a/docs/defradb/dql/aggregating-functions.md
+++ b/docs/defradb/dql/aggregating-functions.md
@@ -8,24 +8,30 @@ The aggregating functions `MIN`, `MAX`, `SUM`, `AVG`, and `COUNT` allow you to c
 <details>
   <summary>Display database setup</summary>
   
-  This page assumes your database contains `Book` and `Person` [collections](/schema/collections.md) and some documents in them:
+  To reproduce the example results from this page, your database needs the following setup.
 
   ```graphql title="Database schema" test-setup-collection
-  type Person {
-    name: String!
-    authoredBooks: [Book]
-  }
-
   type Book {
     title: String!
     genre: String
     plot: String
     rating: Float
-    author: Person
     ratings: [Float]
+    author: Person
+    seller: Company
+  }
+  
+  type Person {
+    name: String!
+    authoredBooks: [Book]
+  }
+
+  type Company {
+    name: String!
+    sells: [Book]
   }
   ```
-  ```graphql title="Person documents setup" test-setup-data
+  ```graphql title="Documents setup" test-setup-data
   mutation {
     a1:add_Person(input: {
       name: "George Orwell"
@@ -39,83 +45,73 @@ The aggregating functions `MIN`, `MAX`, `SUM`, `AVG`, and `COUNT` allow you to c
     a4:add_Person(input: {
       name: "Victor Hugo"
     }) { _docID name }
-  }
-  ```
-  ```graphql title="Book documents setup" test-setup-data
-  mutation {
+
+    c1:add_Company(input: {
+      name: "The Independent Hipster Bookshop"
+    }) { _docID name }
+    c2:add_Company(input: {
+      name: "The World-Destroying Large Chain"
+    }) { _docID name }
+  
     b11:add_Book(input: {
       title: "1984",
       genre: "Fiction",
       plot: "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
       rating: 4.20,
       ratings: [3.8, 4.91, 3.1, 2.8],
-      _authorID: "bae-f630242e-3faf-525e-864c-422e09b00667"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b12:add_Book(input: {
       title: "Down and Out in Paris and London",
       genre: "Memoir",
       plot: "The adventures of a penniless British writer among the down-and-outs of two great cities.",
       rating: 4.09,
-      _authorID: "bae-f630242e-3faf-525e-864c-422e09b00667"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b21:add_Book(input: {
       title: "Lord of the Flies",
       genre: "Fiction",
       plot: "At the dawn of the next world war, a plane crashes on an uncharted island, stranding a group of schoolboys.",
       rating: 3.70,
-      _authorID: "bae-db573e8d-2466-55b9-8da0-39003f530d44"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-6025af65-e57e-5db5-84dd-d349b130c6d9",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b31:add_Book(input: {
       title: "Infinite Jest",
       genre: "Fiction",
       plot: "A gargantuan, mind-altering tragi-comedy about the Pursuit of Happiness in America.",
       rating: 4.25,
       ratings: [3.1, 4.1, 4.5],
-      _authorID: "bae-40b16347-07e0-5e97-85e0-8742eaba786e"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b32:add_Book(input: {
       title: "Consider the Lobster and Other Essays",
       genre: "Nonfiction",
       plot: "Do lobsters feel pain? Did Franz Kafka have a funny bone? What is John Updike's deal, anyway? And what happens when adult video starlets meet their fans in person? Essays that are also enthralling narrative adventures.",
       rating: 4.18,
-      _authorID: "bae-40b16347-07e0-5e97-85e0-8742eaba786e"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b33:add_Book(input: {
       title: "Girl with Curious Hair",
       genre: "Fiction",
       plot: "Remarkable and unsettling reimaginations of reality.",
       rating: 3.85,
-      _authorID: "bae-40b16347-07e0-5e97-85e0-8742eaba786e"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b41:add_Book(input: {
       title: "Les Misérables",
       genre: "Fiction",
       plot: "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
       rating: 4.21,
       ratings: [3.9, 4.1],
-      _authorID: "bae-7f9e6642-03e3-5f62-b684-3d5555f46f7d"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-4bfe5f4c-d668-5dc3-9de2-eb598af3da7d",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
   }
   ```
 </details>
@@ -124,7 +120,7 @@ The aggregating functions `MIN`, `MAX`, `SUM`, `AVG`, and `COUNT` allow you to c
 
 <Tabs groupId="aggregating-funcs">
   <TabItem value="MIN" label="MIN" default>
-    ```graphql title="Syntax &ndash; MIN"
+    ```graphql title="Syntax &ndash; MIN" test-skip
     MIN(GROUP: { 
       field: String, 
       filter: Object,
@@ -136,7 +132,7 @@ The aggregating functions `MIN`, `MAX`, `SUM`, `AVG`, and `COUNT` allow you to c
     - `limit, offset` &ndash; Restrict how many documents are included, see [Limit and paginate results](limit-paginate.md).
   </TabItem>
   <TabItem value="MAX" label="MAX" default>
-    ```graphql title="Syntax &ndash; MAX"
+    ```graphql title="Syntax &ndash; MAX" test-skip
     MAX(GROUP: { 
       field: String, 
       filter: Object,
@@ -148,7 +144,7 @@ The aggregating functions `MIN`, `MAX`, `SUM`, `AVG`, and `COUNT` allow you to c
     - `limit, offset` &ndash; Restrict how many documents are included, see [Limit and paginate results](limit-paginate.md).
   </TabItem>
   <TabItem value="SUM" label="SUM" default>
-    ```graphql title="Syntax &ndash; SUM"
+    ```graphql title="Syntax &ndash; SUM" test-skip
     SUM(GROUP: { 
       field: String, 
       filter: Object,
@@ -160,7 +156,7 @@ The aggregating functions `MIN`, `MAX`, `SUM`, `AVG`, and `COUNT` allow you to c
     - `limit, offset` &ndash; Restrict how many documents are included, see [Limit and paginate results](limit-paginate.md).
   </TabItem>
   <TabItem value="AVG" label="AVG" default>
-    ```graphql title="Syntax &ndash; AVG"
+    ```graphql title="Syntax &ndash; AVG" test-skip
     AVG(GROUP: { 
       field: String, 
       filter: Object,
@@ -172,7 +168,7 @@ The aggregating functions `MIN`, `MAX`, `SUM`, `AVG`, and `COUNT` allow you to c
     - `limit, offset` &ndash; Restrict how many documents are included, see [Limit and paginate results](limit-paginate.md).
   </TabItem>
   <TabItem value="COUNT" label="COUNT" default>
-    ```graphql title="Syntax &ndash; COUNT"
+    ```graphql title="Syntax &ndash; COUNT" test-skip
     COUNT(GROUP: { 
       filter: Object,
       limit: Int, offset: Int
@@ -208,14 +204,6 @@ When [grouping results](group.md), aggregating functions take as input the docum
         "AVG": 4.042,
         "GROUP": [
           {
-            "rating": 4.21,
-            "title": "Les Misérables"
-          },
-          {
-            "rating": 4.25,
-            "title": "Infinite Jest"
-          },
-          {
             "rating": 4.2,
             "title": "1984"
           },
@@ -224,22 +212,19 @@ When [grouping results](group.md), aggregating functions take as input the docum
             "title": "Lord of the Flies"
           },
           {
+            "rating": 4.25,
+            "title": "Infinite Jest"
+          },
+          {
             "rating": 3.85,
             "title": "Girl with Curious Hair"
+          },
+          {
+            "rating": 4.21,
+            "title": "Les Misérables"
           }
         ],
         "genre": "Fiction"
-      },
-      {
-        // highlight-next-line
-        "AVG": 4.18,
-        "GROUP": [
-          {
-            "rating": 4.18,
-            "title": "Consider the Lobster and Other Essays"
-          }
-        ],
-        "genre": "Nonfiction"
       },
       {
         // highlight-next-line
@@ -251,6 +236,17 @@ When [grouping results](group.md), aggregating functions take as input the docum
           }
         ],
         "genre": "Memoir"
+      },
+      {
+        // highlight-next-line
+        "AVG": 4.18,
+        "GROUP": [
+          {
+            "rating": 4.18,
+            "title": "Consider the Lobster and Other Essays"
+          }
+        ],
+        "genre": "Nonfiction"
       }
     ]
   }
@@ -277,32 +273,22 @@ When [grouping results](group.md), aggregating functions take as input the docum
         "COUNT": 5,
         "GROUP": [
           {
-            "title": "Les Misérables"
-          },
-          {
-            "title": "Infinite Jest"
-          },
-          {
             "title": "1984"
           },
           {
             "title": "Lord of the Flies"
           },
           {
+            "title": "Infinite Jest"
+          },
+          {
             "title": "Girl with Curious Hair"
+          },
+          {
+            "title": "Les Misérables"
           }
         ],
         "genre": "Fiction"
-      },
-      {
-        // highlight-next-line
-        "COUNT": 1,
-        "GROUP": [
-          {
-            "title": "Consider the Lobster and Other Essays"
-          }
-        ],
-        "genre": "Nonfiction"
       },
       {
         // highlight-next-line
@@ -313,6 +299,16 @@ When [grouping results](group.md), aggregating functions take as input the docum
           }
         ],
         "genre": "Memoir"
+      },
+      {
+        // highlight-next-line
+        "COUNT": 1,
+        "GROUP": [
+          {
+            "title": "Consider the Lobster and Other Essays"
+          }
+        ],
+        "genre": "Nonfiction"
       }
     ]
   }
@@ -346,14 +342,6 @@ Note how the following example result differs from the previous one only in the 
         "AVG": 4.22,
         "GROUP": [
           {
-            "rating": 4.21,
-            "title": "Les Misérables"
-          },
-          {
-            "rating": 4.25,
-            "title": "Infinite Jest"
-          },
-          {
             "rating": 4.2,
             "title": "1984"
           },
@@ -362,23 +350,22 @@ Note how the following example result differs from the previous one only in the 
             "title": "Lord of the Flies"
           },
           {
+            "rating": 4.25,
+            "title": "Infinite Jest"
+          },
+          {
             "rating": 3.85,
             "title": "Girl with Curious Hair"
+          },
+          {
+            "rating": 4.21,
+            "title": "Les Misérables"
           }
         ],
         "genre": "Fiction"
       },
       {
-        "AVG": 4.18,
-        "GROUP": [
-          {
-            "rating": 4.18,
-            "title": "Consider the Lobster and Other Essays"
-          }
-        ],
-        "genre": "Nonfiction"
-      },
-      {
+        // highlight-next-line
         "AVG": 4.09,
         "GROUP": [
           {
@@ -387,6 +374,17 @@ Note how the following example result differs from the previous one only in the 
           }
         ],
         "genre": "Memoir"
+      },
+      {
+        // highlight-next-line
+        "AVG": 4.18,
+        "GROUP": [
+          {
+            "rating": 4.18,
+            "title": "Consider the Lobster and Other Essays"
+          }
+        ],
+        "genre": "Nonfiction"
       }
     ]
   }
@@ -423,34 +421,6 @@ When [grouping on multiple fields](group.md#multiple-fields), you can run an agg
       {
         "GROUP": [
           {
-            "AVG": 4.21,
-            "GROUP": [
-              {
-                "rating": 4.21,
-                "title": "Les Misérables"
-              }
-            ],
-            "author": {
-              "name": "Victor Hugo"
-            }
-          },
-          {
-            "AVG": 4.05,
-            "GROUP": [
-              {
-                "rating": 4.25,
-                "title": "Infinite Jest"
-              },
-              {
-                "rating": 3.85,
-                "title": "Girl with Curious Hair"
-              }
-            ],
-            "author": {
-              "name": "David Foster Wallace"
-            }
-          },
-          {
             "AVG": 4.2,
             "GROUP": [
               {
@@ -473,36 +443,42 @@ When [grouping on multiple fields](group.md#multiple-fields), you can run an agg
             "author": {
               "name": "William Golding"
             }
-          }
-        ],
-        // highlight-next-line
-        "MAX": 4.21,
-        "author": {
-          "name": "David Foster Wallace"
-        },
-        "genre": "Fiction"
-      },
-      {
-        "GROUP": [
+          },
           {
-            "AVG": 4.18,
+            "AVG": 4.05,
             "GROUP": [
               {
-                "rating": 4.18,
-                "title": "Consider the Lobster and Other Essays"
+                "rating": 4.25,
+                "title": "Infinite Jest"
+              },
+              {
+                "rating": 3.85,
+                "title": "Girl with Curious Hair"
               }
             ],
             "author": {
               "name": "David Foster Wallace"
             }
+          },
+          {
+            "AVG": 4.21,
+            "GROUP": [
+              {
+                "rating": 4.21,
+                "title": "Les Misérables"
+              }
+            ],
+            "author": {
+              "name": "Victor Hugo"
+            }
           }
         ],
         // highlight-next-line
-        "MAX": 4.18,
+        "MAX": 4.21,
         "author": {
-          "name": "David Foster Wallace"
+          "name": "Victor Hugo"
         },
-        "genre": "Nonfiction"
+        "genre": "Fiction"
       },
       {
         "GROUP": [
@@ -525,6 +501,28 @@ When [grouping on multiple fields](group.md#multiple-fields), you can run an agg
           "name": "George Orwell"
         },
         "genre": "Memoir"
+      },
+      {
+        "GROUP": [
+          {
+            "AVG": 4.18,
+            "GROUP": [
+              {
+                "rating": 4.18,
+                "title": "Consider the Lobster and Other Essays"
+              }
+            ],
+            "author": {
+              "name": "David Foster Wallace"
+            }
+          }
+        ],
+        // highlight-next-line
+        "MAX": 4.18,
+        "author": {
+          "name": "David Foster Wallace"
+        },
+        "genre": "Nonfiction"
       }
     ]
   }

--- a/docs/defradb/dql/aliases.md
+++ b/docs/defradb/dql/aliases.md
@@ -8,100 +8,110 @@ Sometimes, _Little Bobby Tables_ is the right name. Other times, you might want 
 <details>
   <summary>Display database setup</summary>
   
-  This page assumes your database contains `Book` and `Person` [collections](/schema/collections.md) and some documents in them:
+  To reproduce the example results from this page, your database needs the following setup.
 
   ```graphql title="Database schema" test-setup-collection
-  type Person {
-    name: String!
-    authoredBooks: [Book]
-  }
-
   type Book {
     title: String!
     genre: String
     plot: String
     rating: Float
+    ratings: [Float]
     author: Person
+    seller: Company
+  }
+  
+  type Person {
+    name: String!
+    authoredBooks: [Book]
+  }
+
+  type Company {
+    name: String!
+    sells: [Book]
   }
   ```
-  ```graphql title="Person documents setup" test-setup-data
+  ```graphql title="Documents setup" test-setup-data
   mutation {
     a1:add_Person(input: {
       name: "George Orwell"
-    }) { _docID }
+    }) { _docID name }
     a2:add_Person(input: {
       name: "William Golding"
-    }) { _docID }
+    }) { _docID name }
     a3:add_Person(input: {
       name: "David Foster Wallace"
-    }) { _docID }
+    }) { _docID name }
     a4:add_Person(input: {
       name: "Victor Hugo"
-    }) { _docID }
-  }
-  ```
-  ```graphql title="Book documents setup" test-setup-data
-  mutation {
+    }) { _docID name }
+
+    c1:add_Company(input: {
+      name: "The Independent Hipster Bookshop"
+    }) { _docID name }
+    c2:add_Company(input: {
+      name: "The World-Destroying Large Chain"
+    }) { _docID name }
+  
     b11:add_Book(input: {
       title: "1984",
       genre: "Fiction",
       plot: "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
       rating: 4.20,
-      _authorID: "bae-3517d1eb-351b-5231-8387-870893ffb395"
-    }) {
-      _docID
-      title
-    }
+      ratings: [3.8, 4.91, 3.1, 2.8],
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b12:add_Book(input: {
       title: "Down and Out in Paris and London",
-      genre: "Biography",
+      genre: "Memoir",
       plot: "The adventures of a penniless British writer among the down-and-outs of two great cities.",
       rating: 4.09,
-      _authorID: "bae-3517d1eb-351b-5231-8387-870893ffb395"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b21:add_Book(input: {
       title: "Lord of the Flies",
       genre: "Fiction",
       plot: "At the dawn of the next world war, a plane crashes on an uncharted island, stranding a group of schoolboys.",
       rating: 3.70,
-      _authorID: "bae-78e9c7be-10b9-5673-bad2-da3341367d4b"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-6025af65-e57e-5db5-84dd-d349b130c6d9",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b31:add_Book(input: {
       title: "Infinite Jest",
       genre: "Fiction",
       plot: "A gargantuan, mind-altering tragi-comedy about the Pursuit of Happiness in America.",
-      rating: 4.25
-      _authorID: "bae-b59928dc-fd05-5fb7-aea2-9b24af5ebcea"
-    }) {
-      _docID
-      title
-    }
+      rating: 4.25,
+      ratings: [3.1, 4.1, 4.5],
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b32:add_Book(input: {
       title: "Consider the Lobster and Other Essays",
       genre: "Nonfiction",
       plot: "Do lobsters feel pain? Did Franz Kafka have a funny bone? What is John Updike's deal, anyway? And what happens when adult video starlets meet their fans in person? Essays that are also enthralling narrative adventures.",
       rating: 4.18,
-      _authorID: "bae-b59928dc-fd05-5fb7-aea2-9b24af5ebcea"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
+    b33:add_Book(input: {
+      title: "Girl with Curious Hair",
+      genre: "Fiction",
+      plot: "Remarkable and unsettling reimaginations of reality.",
+      rating: 3.85,
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b41:add_Book(input: {
       title: "Les Misérables",
       genre: "Fiction",
       plot: "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
       rating: 4.21,
-      _authorID: "bae-c169e917-df52-5603-9224-39c1757f1b04"
-    }) {
-      _docID
-      title
-    }
+      ratings: [3.9, 4.1],
+      _authorID: "bae-4bfe5f4c-d668-5dc3-9de2-eb598af3da7d",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
   }
   ```
 </details>
@@ -192,14 +202,14 @@ You must alias queries when one request contains multiple queries to the same ty
         "title": "Lord of the Flies"
       },
       {
-        "genre": "Biography",
-        "plot": "The adventures of a penniless British writer among the down-and-outs of two great cities.",
-        "title": "Down and Out in Paris and London"
+        "genre": "Fiction",
+        "plot": "Remarkable and unsettling reimaginations of reality.",
+        "title": "Girl with Curious Hair"
       },
       {
-        "genre": "Nonfiction",
-        "plot": "Do lobsters feel pain? Did Franz Kafka have a funny bone? What is John Updike's deal, anyway? And what happens when adult video starlets meet their fans in person? Essays that are also enthralling narrative adventures.",
-        "title": "Consider the Lobster and Other Essays"
+        "genre": "Memoir",
+        "plot": "The adventures of a penniless British writer among the down-and-outs of two great cities.",
+        "title": "Down and Out in Paris and London"
       }
     ]
   }
@@ -212,7 +222,7 @@ To rename the return key for a field, prefix the custom name to the field in the
 
 ```graphql title='Rename the field "plot" to "description"'
 {
-  Book(limit: 1) {
+  Book(filter: { title: { _eq: "1984" } }) {
     title
     genre
     # highlight-next-line
@@ -225,9 +235,9 @@ To rename the return key for a field, prefix the custom name to the field in the
   "data": {
     "Book": [
       {
-        "description": "At the dawn of the next world war, a plane crashes on an uncharted island, stranding a group of schoolboys.",
+        "description": "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
         "genre": "Fiction",
-        "title": "Lord of the Flies"
+        "title": "1984"
       }
     ]
   }

--- a/docs/defradb/dql/filter.md
+++ b/docs/defradb/dql/filter.md
@@ -12,21 +12,27 @@ The `filter` object allow you to specify criteria for selecting documents. You c
 <details>
   <summary>Display database setup</summary>
   
-  This page assumes your database contains `Book` and `Person` [collections](/schema/collections.md) and some documents in them:
+  To reproduce the example results from this page, your database needs the following setup.
 
   ```graphql title="Database schema" test-setup-collection
-  type Person {
-    name: String!
-    authoredBooks: [Book]
-  }
-
   type Book {
     title: String!
     genre: String
     plot: String
     rating: Float
-    author: Person
     ratings: [Float]
+    author: Person
+    seller: Company
+  }
+  
+  type Person {
+    name: String!
+    authoredBooks: [Book]
+  }
+
+  type Company {
+    name: String!
+    sells: [Book]
   }
   ```
   ```graphql title="Documents setup" test-setup-data
@@ -43,6 +49,13 @@ The `filter` object allow you to specify criteria for selecting documents. You c
     a4:add_Person(input: {
       name: "Victor Hugo"
     }) { _docID name }
+
+    c1:add_Company(input: {
+      name: "The Independent Hipster Bookshop"
+    }) { _docID name }
+    c2:add_Company(input: {
+      name: "The World-Destroying Large Chain"
+    }) { _docID name }
   
     b11:add_Book(input: {
       title: "1984",
@@ -50,21 +63,24 @@ The `filter` object allow you to specify criteria for selecting documents. You c
       plot: "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
       rating: 4.20,
       ratings: [3.8, 4.91, 3.1, 2.8],
-      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6"
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
     }) { _docID title }
     b12:add_Book(input: {
       title: "Down and Out in Paris and London",
-      genre: "Biography",
+      genre: "Memoir",
       plot: "The adventures of a penniless British writer among the down-and-outs of two great cities.",
       rating: 4.09,
-      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6"
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
     }) { _docID title }
     b21:add_Book(input: {
       title: "Lord of the Flies",
       genre: "Fiction",
       plot: "At the dawn of the next world war, a plane crashes on an uncharted island, stranding a group of schoolboys.",
       rating: 3.70,
-      _authorID: "bae-6025af65-e57e-5db5-84dd-d349b130c6d9"
+      _authorID: "bae-6025af65-e57e-5db5-84dd-d349b130c6d9",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
     }) { _docID title }
     b31:add_Book(input: {
       title: "Infinite Jest",
@@ -72,14 +88,24 @@ The `filter` object allow you to specify criteria for selecting documents. You c
       plot: "A gargantuan, mind-altering tragi-comedy about the Pursuit of Happiness in America.",
       rating: 4.25,
       ratings: [3.1, 4.1, 4.5],
-      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915"
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
     }) { _docID title }
     b32:add_Book(input: {
       title: "Consider the Lobster and Other Essays",
       genre: "Nonfiction",
       plot: "Do lobsters feel pain? Did Franz Kafka have a funny bone? What is John Updike's deal, anyway? And what happens when adult video starlets meet their fans in person? Essays that are also enthralling narrative adventures.",
       rating: 4.18,
-      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915"
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
+    b33:add_Book(input: {
+      title: "Girl with Curious Hair",
+      genre: "Fiction",
+      plot: "Remarkable and unsettling reimaginations of reality.",
+      rating: 3.85,
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
     }) { _docID title }
     b41:add_Book(input: {
       title: "Les Misérables",
@@ -87,7 +113,8 @@ The `filter` object allow you to specify criteria for selecting documents. You c
       plot: "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
       rating: 4.21,
       ratings: [3.9, 4.1],
-      _authorID: "bae-4bfe5f4c-d668-5dc3-9de2-eb598af3da7d"
+      _authorID: "bae-4bfe5f4c-d668-5dc3-9de2-eb598af3da7d",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
     }) { _docID title }
   }
   ```
@@ -242,24 +269,14 @@ filter: {
   "data": {
     "Book": [
       {
-        "genre": "Biography",
+        "genre": "Fiction",
+        "rating": 4.2,
+        "title": "1984"
+      },
+      {
+        "genre": "Memoir",
         "rating": 4.09,
         "title": "Down and Out in Paris and London"
-      },
-      {
-        "genre": "Nonfiction",
-        "rating": 4.18,
-        "title": "Consider the Lobster and Other Essays"
-      },
-      {
-        "genre": "Fiction",
-        "rating": 4.25,
-        "title": "Infinite Jest"
-      },
-      {
-        "genre": "Fiction",
-        "rating": 4.21,
-        "title": "Les Misérables"
       },
       {
         "genre": "Fiction",
@@ -268,8 +285,23 @@ filter: {
       },
       {
         "genre": "Fiction",
-        "rating": 4.2,
-        "title": "1984"
+        "rating": 4.25,
+        "title": "Infinite Jest"
+      },
+      {
+        "genre": "Nonfiction",
+        "rating": 4.18,
+        "title": "Consider the Lobster and Other Essays"
+      },
+      {
+        "genre": "Fiction",
+        "rating": 3.85,
+        "title": "Girl with Curious Hair"
+      },
+      {
+        "genre": "Fiction",
+        "rating": 4.21,
+        "title": "Les Misérables"
       }
     ]
   }
@@ -295,7 +327,7 @@ The boolean operators `_and` and `_or` accept an array, whereas `_not` accepts a
   "data": {
     "Book": [
       {
-        "genre": "Biography",
+        "genre": "Memoir",
         "title": "Down and Out in Paris and London"
       },
       {
@@ -401,12 +433,12 @@ If the return fields include the sub-object you filter on, the same filter is **
       {
         "authoredBooks": [
           {
-            "genre": "Biography",
-            "title": "Down and Out in Paris and London"
-          },
-          {
             "genre": "Fiction",
             "title": "1984"
+          },
+          {
+            "genre": "Memoir",
+            "title": "Down and Out in Paris and London"
           }
         ],
         "name": "George Orwell"
@@ -423,12 +455,16 @@ If the return fields include the sub-object you filter on, the same filter is **
       {
         "authoredBooks": [
           {
+            "genre": "Fiction",
+            "title": "Infinite Jest"
+          },
+          {
             "genre": "Nonfiction",
             "title": "Consider the Lobster and Other Essays"
           },
           {
             "genre": "Fiction",
-            "title": "Infinite Jest"
+            "title": "Girl with Curious Hair"
           }
         ],
         "name": "David Foster Wallace"
@@ -613,20 +649,20 @@ The [list operators](#list-operators) `_any`, `_none`, `_all` evaluate a scalar 
     "Book": [
       {
         "ratings": [
-          3.1,
-          4.1,
-          4.5
-        ],
-        "title": "Infinite Jest"
-      },
-      {
-        "ratings": [
           3.8,
           4.91,
           3.1,
           2.8
         ],
         "title": "1984"
+      },
+      {
+        "ratings": [
+          3.1,
+          4.1,
+          4.5
+        ],
+        "title": "Infinite Jest"
       }
     ]
   }

--- a/docs/defradb/dql/group.md
+++ b/docs/defradb/dql/group.md
@@ -8,24 +8,30 @@ The `groupBy` argument allows you to group results into buckets basing on the va
 <details>
   <summary>Display database setup</summary>
   
-  This page assumes your database contains `Book` and `Person` [collections](/schema/collections.md) and some documents in them:
+  To reproduce the example results from this page, your database needs the following setup.
 
   ```graphql title="Database schema" test-setup-collection
-  type Person {
-    name: String!
-    authoredBooks: [Book]
-  }
-
   type Book {
     title: String!
     genre: String
     plot: String
     rating: Float
-    author: Person
     ratings: [Float]
+    author: Person
+    seller: Company
+  }
+  
+  type Person {
+    name: String!
+    authoredBooks: [Book]
+  }
+
+  type Company {
+    name: String!
+    sells: [Book]
   }
   ```
-  ```graphql title="Person documents setup" test-setup-data
+  ```graphql title="Documents setup" test-setup-data
   mutation {
     a1:add_Person(input: {
       name: "George Orwell"
@@ -39,83 +45,73 @@ The `groupBy` argument allows you to group results into buckets basing on the va
     a4:add_Person(input: {
       name: "Victor Hugo"
     }) { _docID name }
-  }
-  ```
-  ```graphql title="Book documents setup" test-setup-data
-  mutation {
+
+    c1:add_Company(input: {
+      name: "The Independent Hipster Bookshop"
+    }) { _docID name }
+    c2:add_Company(input: {
+      name: "The World-Destroying Large Chain"
+    }) { _docID name }
+  
     b11:add_Book(input: {
       title: "1984",
       genre: "Fiction",
       plot: "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
       rating: 4.20,
       ratings: [3.8, 4.91, 3.1, 2.8],
-      _authorID: "bae-f630242e-3faf-525e-864c-422e09b00667"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b12:add_Book(input: {
       title: "Down and Out in Paris and London",
       genre: "Memoir",
       plot: "The adventures of a penniless British writer among the down-and-outs of two great cities.",
       rating: 4.09,
-      _authorID: "bae-f630242e-3faf-525e-864c-422e09b00667"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b21:add_Book(input: {
       title: "Lord of the Flies",
       genre: "Fiction",
       plot: "At the dawn of the next world war, a plane crashes on an uncharted island, stranding a group of schoolboys.",
       rating: 3.70,
-      _authorID: "bae-db573e8d-2466-55b9-8da0-39003f530d44"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-6025af65-e57e-5db5-84dd-d349b130c6d9",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b31:add_Book(input: {
       title: "Infinite Jest",
       genre: "Fiction",
       plot: "A gargantuan, mind-altering tragi-comedy about the Pursuit of Happiness in America.",
       rating: 4.25,
       ratings: [3.1, 4.1, 4.5],
-      _authorID: "bae-40b16347-07e0-5e97-85e0-8742eaba786e"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b32:add_Book(input: {
       title: "Consider the Lobster and Other Essays",
       genre: "Nonfiction",
       plot: "Do lobsters feel pain? Did Franz Kafka have a funny bone? What is John Updike's deal, anyway? And what happens when adult video starlets meet their fans in person? Essays that are also enthralling narrative adventures.",
       rating: 4.18,
-      _authorID: "bae-40b16347-07e0-5e97-85e0-8742eaba786e"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b33:add_Book(input: {
       title: "Girl with Curious Hair",
       genre: "Fiction",
       plot: "Remarkable and unsettling reimaginations of reality.",
       rating: 3.85,
-      _authorID: "bae-40b16347-07e0-5e97-85e0-8742eaba786e"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b41:add_Book(input: {
       title: "Les Misérables",
       genre: "Fiction",
       plot: "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
       rating: 4.21,
       ratings: [3.9, 4.1],
-      _authorID: "bae-7f9e6642-03e3-5f62-b684-3d5555f46f7d"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-4bfe5f4c-d668-5dc3-9de2-eb598af3da7d",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
   }
   ```
 </details>
@@ -161,20 +157,6 @@ The return object can only include the grouped-by fields, the `GROUP` sub-object
         "GROUP": [
           {
             "author": {
-              "name": "Victor Hugo"
-            },
-            "plot": "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
-            "title": "Les Misérables"
-          },
-          {
-            "author": {
-              "name": "David Foster Wallace"
-            },
-            "plot": "A gargantuan, mind-altering tragi-comedy about the Pursuit of Happiness in America.",
-            "title": "Infinite Jest"
-          },
-          {
-            "author": {
               "name": "George Orwell"
             },
             "plot": "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
@@ -191,23 +173,25 @@ The return object can only include the grouped-by fields, the `GROUP` sub-object
             "author": {
               "name": "David Foster Wallace"
             },
-            "plot": "Remarkable and unsettling reimaginations of reality.",
-            "title": "Girl with Curious Hair"
-          }
-        ],
-        "genre": "Fiction"
-      },
-      {
-        "GROUP": [
+            "plot": "A gargantuan, mind-altering tragi-comedy about the Pursuit of Happiness in America.",
+            "title": "Infinite Jest"
+          },
           {
             "author": {
               "name": "David Foster Wallace"
             },
-            "plot": "Do lobsters feel pain? Did Franz Kafka have a funny bone? What is John Updike's deal, anyway? And what happens when adult video starlets meet their fans in person? Essays that are also enthralling narrative adventures.",
-            "title": "Consider the Lobster and Other Essays"
+            "plot": "Remarkable and unsettling reimaginations of reality.",
+            "title": "Girl with Curious Hair"
+          },
+          {
+            "author": {
+              "name": "Victor Hugo"
+            },
+            "plot": "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
+            "title": "Les Misérables"
           }
         ],
-        "genre": "Nonfiction"
+        "genre": "Fiction"
       },
       {
         "GROUP": [
@@ -220,6 +204,18 @@ The return object can only include the grouped-by fields, the `GROUP` sub-object
           }
         ],
         "genre": "Memoir"
+      },
+      {
+        "GROUP": [
+          {
+            "author": {
+              "name": "David Foster Wallace"
+            },
+            "plot": "Do lobsters feel pain? Did Franz Kafka have a funny bone? What is John Updike's deal, anyway? And what happens when adult video starlets meet their fans in person? Essays that are also enthralling narrative adventures.",
+            "title": "Consider the Lobster and Other Essays"
+          }
+        ],
+        "genre": "Nonfiction"
       }
     ]
   }
@@ -272,12 +268,12 @@ You can group results by a relationship fields as well. You can only group by th
       {
         "GROUP": [
           {
-            "plot": "The adventures of a penniless British writer among the down-and-outs of two great cities.",
-            "title": "Down and Out in Paris and London"
-          },
-          {
             "plot": "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
             "title": "1984"
+          },
+          {
+            "plot": "The adventures of a penniless British writer among the down-and-outs of two great cities.",
+            "title": "Down and Out in Paris and London"
           }
         ],
         "author": {
@@ -341,6 +337,16 @@ To create groups basing on the value of multiple fields, you have two options:
           {
             "GROUP": [
               {
+                "title": "1984"
+              }
+            ],
+            "author": {
+              "name": "George Orwell"
+            }
+          },
+          {
+            "GROUP": [
+              {
                 "title": "Lord of the Flies"
               }
             ],
@@ -351,14 +357,14 @@ To create groups basing on the value of multiple fields, you have two options:
           {
             "GROUP": [
               {
-                "title": "1985"
+                "title": "Infinite Jest"
               },
               {
-                "title": "1984"
+                "title": "Girl with Curious Hair"
               }
             ],
             "author": {
-              "name": "George Orwell"
+              "name": "David Foster Wallace"
             }
           },
           {
@@ -370,22 +376,30 @@ To create groups basing on the value of multiple fields, you have two options:
             "author": {
               "name": "Victor Hugo"
             }
-          },
+          }
+        ],
+        "author": {
+          "name": "Victor Hugo"
+        },
+        "genre": "Fiction"
+      },
+      {
+        "GROUP": [
           {
             "GROUP": [
               {
-                "title": "Infinite Jest"
+                "title": "Down and Out in Paris and London"
               }
             ],
             "author": {
-              "name": "David Foster Wallace"
+              "name": "George Orwell"
             }
           }
         ],
         "author": {
           "name": "George Orwell"
         },
-        "genre": "Fiction"
+        "genre": "Memoir"
       },
       {
         "GROUP": [
@@ -404,24 +418,6 @@ To create groups basing on the value of multiple fields, you have two options:
           "name": "David Foster Wallace"
         },
         "genre": "Nonfiction"
-      },
-      {
-        "GROUP": [
-          {
-            "GROUP": [
-              {
-                "title": "Down and Out in Paris and London"
-              }
-            ],
-            "author": {
-              "name": "George Orwell"
-            }
-          }
-        ],
-        "author": {
-          "name": "George Orwell"
-        },
-        "genre": "Biography"
       }
     ]
   }
@@ -446,11 +442,33 @@ To create groups basing on the value of multiple fields, you have two options:
       {
         "GROUP": [
           {
-            "title": "Les Misérables"
+            "title": "1984"
           }
         ],
         "author": {
-          "name": "Victor Hugo"
+          "name": "George Orwell"
+        },
+        "genre": "Fiction"
+      },
+      {
+        "GROUP": [
+          {
+            "title": "Down and Out in Paris and London"
+          }
+        ],
+        "author": {
+          "name": "George Orwell"
+        },
+        "genre": "Memoir"
+      },
+      {
+        "GROUP": [
+          {
+            "title": "Lord of the Flies"
+          }
+        ],
+        "author": {
+          "name": "William Golding"
         },
         "genre": "Fiction"
       },
@@ -482,33 +500,11 @@ To create groups basing on the value of multiple fields, you have two options:
       {
         "GROUP": [
           {
-            "title": "Down and Out in Paris and London"
+            "title": "Les Misérables"
           }
         ],
         "author": {
-          "name": "George Orwell"
-        },
-        "genre": "Memoir"
-      },
-      {
-        "GROUP": [
-          {
-            "title": "1984"
-          }
-        ],
-        "author": {
-          "name": "George Orwell"
-        },
-        "genre": "Fiction"
-      },
-      {
-        "GROUP": [
-          {
-            "title": "Lord of the Flies"
-          }
-        ],
-        "author": {
-          "name": "William Golding"
+          "name": "Victor Hugo"
         },
         "genre": "Fiction"
       }
@@ -577,19 +573,19 @@ The interplay between root and `GROUP` arguments can be subtle. When grouping re
       {
         "GROUP": [
           {
-            "title": "Les Misérables"
-          },
-          {
-            "title": "Infinite Jest"
-          },
-          {
             "title": "1984"
           },
           {
             "title": "Lord of the Flies"
           },
           {
+            "title": "Infinite Jest"
+          },
+          {
             "title": "Girl with Curious Hair"
+          },
+          {
+            "title": "Les Misérables"
           }
         ],
         "genre": "Fiction"
@@ -618,18 +614,10 @@ The interplay between root and `GROUP` arguments can be subtle. When grouping re
       {
         "GROUP": [
           {
-            "title": "Les Misérables"
+            "title": "1984"
           }
         ],
         "genre": "Fiction"
-      },
-      {
-        "GROUP": [
-          {
-            "title": "Consider the Lobster and Other Essays"
-          }
-        ],
-        "genre": "Nonfiction"
       },
       {
         "GROUP": [
@@ -638,6 +626,14 @@ The interplay between root and `GROUP` arguments can be subtle. When grouping re
           }
         ],
         "genre": "Memoir"
+      },
+      {
+        "GROUP": [
+          {
+            "title": "Consider the Lobster and Other Essays"
+          }
+        ],
+        "genre": "Nonfiction"
       }
     ]
   }
@@ -720,11 +716,11 @@ Filters at the `GROUP` level allow you to restrict the groups to get only some s
       },
       {
         "GROUP": [],
-        "genre": "Nonfiction"
+        "genre": "Memoir"
       },
       {
         "GROUP": [],
-        "genre": "Memoir"
+        "genre": "Nonfiction"
       }
     ]
   }

--- a/docs/defradb/dql/limit-paginate.md
+++ b/docs/defradb/dql/limit-paginate.md
@@ -9,100 +9,110 @@ The `limit` and `offset` keywords allow you to control how many records a query 
 <details>
   <summary>Display database setup</summary>
   
-  This page assumes your database contains `Book` and `Person` [collections](/schema/collections.md) and some documents in them:
+  To reproduce the example results from this page, your database needs the following setup.
 
   ```graphql title="Database schema" test-setup-collection
-  type Person {
-    name: String!
-    authoredBooks: [Book]
-  }
-
   type Book {
     title: String!
     genre: String
     plot: String
     rating: Float
+    ratings: [Float]
     author: Person
+    seller: Company
+  }
+  
+  type Person {
+    name: String!
+    authoredBooks: [Book]
+  }
+
+  type Company {
+    name: String!
+    sells: [Book]
   }
   ```
-  ```graphql title="Person documents setup" test-setup-data
+  ```graphql title="Documents setup" test-setup-data
   mutation {
     a1:add_Person(input: {
       name: "George Orwell"
-    }) { _docID }
+    }) { _docID name }
     a2:add_Person(input: {
       name: "William Golding"
-    }) { _docID }
+    }) { _docID name }
     a3:add_Person(input: {
       name: "David Foster Wallace"
-    }) { _docID }
+    }) { _docID name }
     a4:add_Person(input: {
       name: "Victor Hugo"
-    }) { _docID }
-  }
-  ```
-  ```graphql title="Book documents setup" test-setup-data
-  mutation {
+    }) { _docID name }
+
+    c1:add_Company(input: {
+      name: "The Independent Hipster Bookshop"
+    }) { _docID name }
+    c2:add_Company(input: {
+      name: "The World-Destroying Large Chain"
+    }) { _docID name }
+  
     b11:add_Book(input: {
       title: "1984",
       genre: "Fiction",
       plot: "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
       rating: 4.20,
-      _authorID: "bae-3517d1eb-351b-5231-8387-870893ffb395"
-    }) {
-      _docID
-      title
-    }
+      ratings: [3.8, 4.91, 3.1, 2.8],
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b12:add_Book(input: {
       title: "Down and Out in Paris and London",
-      genre: "Biography",
+      genre: "Memoir",
       plot: "The adventures of a penniless British writer among the down-and-outs of two great cities.",
       rating: 4.09,
-      _authorID: "bae-3517d1eb-351b-5231-8387-870893ffb395"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b21:add_Book(input: {
       title: "Lord of the Flies",
       genre: "Fiction",
       plot: "At the dawn of the next world war, a plane crashes on an uncharted island, stranding a group of schoolboys.",
       rating: 3.70,
-      _authorID: "bae-78e9c7be-10b9-5673-bad2-da3341367d4b"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-6025af65-e57e-5db5-84dd-d349b130c6d9",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b31:add_Book(input: {
       title: "Infinite Jest",
       genre: "Fiction",
       plot: "A gargantuan, mind-altering tragi-comedy about the Pursuit of Happiness in America.",
-      rating: 4.25
-      _authorID: "bae-b59928dc-fd05-5fb7-aea2-9b24af5ebcea"
-    }) {
-      _docID
-      title
-    }
+      rating: 4.25,
+      ratings: [3.1, 4.1, 4.5],
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b32:add_Book(input: {
       title: "Consider the Lobster and Other Essays",
       genre: "Nonfiction",
       plot: "Do lobsters feel pain? Did Franz Kafka have a funny bone? What is John Updike's deal, anyway? And what happens when adult video starlets meet their fans in person? Essays that are also enthralling narrative adventures.",
       rating: 4.18,
-      _authorID: "bae-b59928dc-fd05-5fb7-aea2-9b24af5ebcea"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
+    b33:add_Book(input: {
+      title: "Girl with Curious Hair",
+      genre: "Fiction",
+      plot: "Remarkable and unsettling reimaginations of reality.",
+      rating: 3.85,
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b41:add_Book(input: {
       title: "Les Misérables",
       genre: "Fiction",
       plot: "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
       rating: 4.21,
-      _authorID: "bae-c169e917-df52-5603-9224-39c1757f1b04"
-    }) {
-      _docID
-      title
-    }
+      ratings: [3.9, 4.1],
+      _authorID: "bae-4bfe5f4c-d668-5dc3-9de2-eb598af3da7d",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
   }
   ```
 </details>

--- a/docs/defradb/dql/mutation-create.md
+++ b/docs/defradb/dql/mutation-create.md
@@ -8,7 +8,7 @@ Once you have [created collections](/schema/collections.md), you can start addin
 <details>
   <summary>Display database setup</summary>
   
-  This page assumes your database contains `Book` and `Person` [collections](/schema/collections.md):
+  To reproduce the example results from this page, your database needs the following setup.
 
   ```graphql title="Database schema" test-setup-collection
   type Person {
@@ -67,7 +67,7 @@ mutation {
       "data": {
         "add_Book": [
           {
-            "_docID": "bae-ad13cbb3-0970-5e1d-8096-620f7bd27d26",
+            "_docID": "bae-db5131b2-2e79-5ae8-ab8b-df35c2b939e1",
             "title": "Infinite Jest"
           }
         ]
@@ -118,7 +118,7 @@ mutation {
       "data": {
         "add_Book": [
           {
-            "_docID": "bae-ad13cbb3-0970-5e1d-8096-620f7bd27d26",
+            "_docID": "bae-db5131b2-2e79-5ae8-ab8b-df35c2b939e1",
             "title": "Infinite Jest"
           }
         ]
@@ -279,13 +279,13 @@ mutation {
   "data": {
     "add_Book": [
       {
-        "_docID": "bae-e1dcefa0-46ca-5ae5-bc0a-859f2e7e1259",
+        "_docID": "bae-097c416c-bb66-5947-b241-c462464ea41d",
         "title": "Les Misérables"
       }
     ],
     "add_Person": [
       {
-        "_docID": "bae-c169e917-df52-5603-9224-39c1757f1b04",
+        "_docID": "bae-4bfe5f4c-d668-5dc3-9de2-eb598af3da7d",
         "name": "Victor Hugo"
       }
     ]
@@ -298,7 +298,7 @@ To link them, use an [update mutation](/dql/mutation-update.md) to set the field
 ```graphql title="Link book and author via Book._authorID"
 mutation {
   update_Book(
-    docID: "bae-e1dcefa0-46ca-5ae5-bc0a-859f2e7e1259",
+    docID: "bae-097c416c-bb66-5947-b241-c462464ea41d",
     input: {  # properties to be altered
       _authorID: "bae-c169e917-df52-5603-9224-39c1757f1b04"
     }
@@ -315,7 +315,7 @@ mutation {
     "update_Book": [
       {
         "_authorID": "bae-c169e917-df52-5603-9224-39c1757f1b04",
-        "_docID": "bae-e1dcefa0-46ca-5ae5-bc0a-859f2e7e1259",
+        "_docID": "bae-097c416c-bb66-5947-b241-c462464ea41d",
         "title": "Les Misérables"
       }
     ]
@@ -323,9 +323,17 @@ mutation {
 }
 ```
 
-## JSON fields
+## JSON fields {/* #json-fields */}
 
 JSON fields expect the value to be an unserialized object, not its string representation.
+
+{/*
+```graphql title='Schema for "jsonBlob" collection' test-setup-collection
+type jsonBlob {
+  jsonField: JSON @index
+}
+```
+*/}
 
 ```graphql title="Valid &ndash; JSON unserialized object"
 #valid

--- a/docs/defradb/dql/mutation-delete.md
+++ b/docs/defradb/dql/mutation-delete.md
@@ -29,100 +29,110 @@ You cannot restore a deleted document, nor re-create a document with the exact s
 <details>
   <summary>Display database setup</summary>
   
-  This page assumes your database contains `Book` and `Person` [collections](/schema/collections.md) and some documents in them:
+  To reproduce the example results from this page, your database needs the following setup.
 
   ```graphql title="Database schema" test-setup-collection
-  type Person {
-    name: String!
-    authoredBooks: [Book]
-  }
-
   type Book {
     title: String!
     genre: String
     plot: String
     rating: Float
+    ratings: [Float]
     author: Person
+    seller: Company
+  }
+  
+  type Person {
+    name: String!
+    authoredBooks: [Book]
+  }
+
+  type Company {
+    name: String!
+    sells: [Book]
   }
   ```
-  ```graphql title="Person documents setup" test-setup-data
+  ```graphql title="Documents setup" test-setup-data
   mutation {
     a1:add_Person(input: {
       name: "George Orwell"
-    }) { _docID }
+    }) { _docID name }
     a2:add_Person(input: {
       name: "William Golding"
-    }) { _docID }
+    }) { _docID name }
     a3:add_Person(input: {
       name: "David Foster Wallace"
-    }) { _docID }
+    }) { _docID name }
     a4:add_Person(input: {
       name: "Victor Hugo"
-    }) { _docID }
-  }
-  ```
-  ```graphql title="Book documents setup" test-setup-data
-  mutation {
+    }) { _docID name }
+
+    c1:add_Company(input: {
+      name: "The Independent Hipster Bookshop"
+    }) { _docID name }
+    c2:add_Company(input: {
+      name: "The World-Destroying Large Chain"
+    }) { _docID name }
+  
     b11:add_Book(input: {
       title: "1984",
       genre: "Dystopia",
       plot: "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
       rating: 4.20,
-      _authorID: "bae-3517d1eb-351b-5231-8387-870893ffb395"
-    }) {
-      _docID
-      title
-    }
+      ratings: [3.8, 4.91, 3.1, 2.8],
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b12:add_Book(input: {
       title: "Down and Out in Paris and London",
-      genre: "Biography",
+      genre: "Memoir",
       plot: "The adventures of a penniless British writer among the down-and-outs of two great cities.",
       rating: 4.09,
-      _authorID: "bae-3517d1eb-351b-5231-8387-870893ffb395"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b21:add_Book(input: {
       title: "Lord of the Flies",
       genre: "Dystopia",
       plot: "At the dawn of the next world war, a plane crashes on an uncharted island, stranding a group of schoolboys.",
       rating: 3.70,
-      _authorID: "bae-78e9c7be-10b9-5673-bad2-da3341367d4b"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-6025af65-e57e-5db5-84dd-d349b130c6d9",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b31:add_Book(input: {
       title: "Infinite Jest",
       genre: "Fiction",
       plot: "A gargantuan, mind-altering tragi-comedy about the Pursuit of Happiness in America.",
-      rating: 4.25
-      _authorID: "bae-b59928dc-fd05-5fb7-aea2-9b24af5ebcea"
-    }) {
-      _docID
-      title
-    }
+      rating: 4.25,
+      ratings: [3.1, 4.1, 4.5],
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b32:add_Book(input: {
       title: "Consider the Lobster and Other Essays",
       genre: "Nonfiction",
       plot: "Do lobsters feel pain? Did Franz Kafka have a funny bone? What is John Updike's deal, anyway? And what happens when adult video starlets meet their fans in person? Essays that are also enthralling narrative adventures.",
       rating: 4.18,
-      _authorID: "bae-b59928dc-fd05-5fb7-aea2-9b24af5ebcea"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
+    b33:add_Book(input: {
+      title: "Girl with Curious Hair",
+      genre: "Fiction",
+      plot: "Remarkable and unsettling reimaginations of reality.",
+      rating: 3.85,
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b41:add_Book(input: {
       title: "Les Misérables",
       genre: "Fiction",
       plot: "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
       rating: 4.21,
-      _authorID: "bae-c169e917-df52-5603-9224-39c1757f1b04"
-    }) {
-      _docID
-      title
-    }
+      ratings: [3.9, 4.1],
+      _authorID: "bae-4bfe5f4c-d668-5dc3-9de2-eb598af3da7d",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
   }
   ```
 </details>
@@ -132,7 +142,6 @@ mutation {
   delete_Person(
     filter: { authoredBooks: { genre: { _eq: "Dystopia" } } } 
   ) {
-    _docID
     name
   }
 }
@@ -142,11 +151,9 @@ mutation {
   "data": {
     "delete_Person": [
       {
-        "_docID": "bae-3517d1eb-351b-5231-8387-870893ffb395",
         "name": "George Orwell"
       },
       {
-        "_docID": "bae-78e9c7be-10b9-5673-bad2-da3341367d4b",
         "name": "William Golding"
       }
     ]

--- a/docs/defradb/dql/mutation-query.md
+++ b/docs/defradb/dql/mutation-query.md
@@ -8,11 +8,21 @@ Once you have [created some documents](mutation-create.md), you can query the da
 <details>
   <summary>Display database setup</summary>
   
-  This page assumes your database contains `Book` and `Person` [collections](/schema/collections.md) and some documents in them:
+  To reproduce the example results from this page, your database needs the following setup.
 
   ```graphql title="Database schema" test-setup-collection
+  type Book {
+    title: String!
+    genre: String
+    plot: String
+    rating: Float
+    ratings: [Float]
+    author: Person
+    seller: Company
+  }
+  
   type Person {
-    name: String
+    name: String!
     authoredBooks: [Book]
   }
 
@@ -20,25 +30,9 @@ Once you have [created some documents](mutation-create.md), you can query the da
     name: String!
     sells: [Book]
   }
-
-  type Book {
-    title: String!
-    genre: String
-    plot: String
-    rating: Float
-    author: Person
-    seller: Company
-  }
   ```
   ```graphql title="Documents setup" test-setup-data
   mutation {
-    c1:add_Company(input: {
-      name: "The Indipendent Hipster Bookshop"
-    }) { _docID name }
-    c2:add_Company(input: {
-      name: "The World-Destroying Large Chain"
-    }) { _docID name }
-  
     a1:add_Person(input: {
       name: "George Orwell"
     }) { _docID name }
@@ -52,53 +46,71 @@ Once you have [created some documents](mutation-create.md), you can query the da
       name: "Victor Hugo"
     }) { _docID name }
 
+    c1:add_Company(input: {
+      name: "The Independent Hipster Bookshop"
+    }) { _docID name }
+    c2:add_Company(input: {
+      name: "The World-Destroying Large Chain"
+    }) { _docID name }
+  
     b11:add_Book(input: {
       title: "1984",
       genre: "Fiction",
       plot: "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
       rating: 4.20,
-      _authorID: "bae-3517d1eb-351b-5231-8387-870893ffb395",
-      _sellerID: "bae-dd31ceba-9ffd-57b6-b6b2-365081ef4b7a"
+      ratings: [3.8, 4.91, 3.1, 2.8],
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
     }) { _docID title }
     b12:add_Book(input: {
       title: "Down and Out in Paris and London",
-      genre: "Biography",
+      genre: "Memoir",
       plot: "The adventures of a penniless British writer among the down-and-outs of two great cities.",
       rating: 4.09,
-      _authorID: "bae-3517d1eb-351b-5231-8387-870893ffb395",
-      _sellerID: "bae-dd31ceba-9ffd-57b6-b6b2-365081ef4b7a"
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
     }) { _docID title }
     b21:add_Book(input: {
       title: "Lord of the Flies",
       genre: "Fiction",
       plot: "At the dawn of the next world war, a plane crashes on an uncharted island, stranding a group of schoolboys.",
       rating: 3.70,
-      _authorID: "bae-78e9c7be-10b9-5673-bad2-da3341367d4b",
-      _sellerID: "bae-e467e3b8-9ba5-52b4-ae6b-4499f2f0c483"
+      _authorID: "bae-6025af65-e57e-5db5-84dd-d349b130c6d9",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
     }) { _docID title }
     b31:add_Book(input: {
       title: "Infinite Jest",
       genre: "Fiction",
       plot: "A gargantuan, mind-altering tragi-comedy about the Pursuit of Happiness in America.",
-      rating: 4.25
-      _authorID: "bae-b59928dc-fd05-5fb7-aea2-9b24af5ebcea",
-      _sellerID: "bae-dd31ceba-9ffd-57b6-b6b2-365081ef4b7a"
+      rating: 4.25,
+      ratings: [3.1, 4.1, 4.5],
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
     }) { _docID title }
     b32:add_Book(input: {
       title: "Consider the Lobster and Other Essays",
       genre: "Nonfiction",
       plot: "Do lobsters feel pain? Did Franz Kafka have a funny bone? What is John Updike's deal, anyway? And what happens when adult video starlets meet their fans in person? Essays that are also enthralling narrative adventures.",
       rating: 4.18,
-      _authorID: "bae-b59928dc-fd05-5fb7-aea2-9b24af5ebcea",
-      _sellerID: "bae-e467e3b8-9ba5-52b4-ae6b-4499f2f0c483"
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
+    b33:add_Book(input: {
+      title: "Girl with Curious Hair",
+      genre: "Fiction",
+      plot: "Remarkable and unsettling reimaginations of reality.",
+      rating: 3.85,
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
     }) { _docID title }
     b41:add_Book(input: {
       title: "Les Misérables",
       genre: "Fiction",
       plot: "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
       rating: 4.21,
-      _authorID: "bae-c169e917-df52-5603-9224-39c1757f1b04",
-      _sellerID: "bae-e467e3b8-9ba5-52b4-ae6b-4499f2f0c483"
+      ratings: [3.9, 4.1],
+      _authorID: "bae-4bfe5f4c-d668-5dc3-9de2-eb598af3da7d",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
     }) { _docID title }
   }
   ```
@@ -133,7 +145,7 @@ Once you have [created some documents](mutation-create.md), you can query the da
       author: { name: { _eq: "George Orwell" } }
     },
     limit: 3,
-    order: { "title": ASC }
+    order: { title: ASC }
   ) {
     title
     plot
@@ -268,34 +280,39 @@ The basic skeleton of a query is made of the type/collection you want to fetch f
       "data": {
         "Book": [
           {
-            "_docID": "bae-526a42c6-c147-57e4-89e0-875d27a1532d",
+            "_docID": "bae-97eeb5cb-04cf-5575-ab00-3e3285ce79b5",
             "plot": "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
             "title": "1984"
           },
           {
-            "_docID": "bae-8a6c163a-29cd-5607-a965-199487e58b00",
-            "plot": "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
-            "title": "Les Misérables"
-          },
-          {
-            "_docID": "bae-92465255-4869-5994-9898-83576ee9ff60",
+            "_docID": "bae-e9acc047-5a1f-5f81-847e-15744fea66a3",
             "plot": "The adventures of a penniless British writer among the down-and-outs of two great cities.",
             "title": "Down and Out in Paris and London"
           },
           {
-            "_docID": "bae-9579541e-f15d-506e-a74a-63d00cb3ab56",
+            "_docID": "bae-7da5622a-8e4f-5ac8-9140-d412a81011be",
             "plot": "At the dawn of the next world war, a plane crashes on an uncharted island, stranding a group of schoolboys.",
             "title": "Lord of the Flies"
           },
           {
-            "_docID": "bae-a3dad950-43cc-5f03-9b33-b61ebc936ac4",
+            "_docID": "bae-d1460b1a-8f78-5791-b0ec-869997260c20",
+            "plot": "A gargantuan, mind-altering tragi-comedy about the Pursuit of Happiness in America.",
+            "title": "Infinite Jest"
+          },
+          {
+            "_docID": "bae-6aaffb28-ddad-57c9-b0c9-0db40a3e3456",
             "plot": "Do lobsters feel pain? Did Franz Kafka have a funny bone? What is John Updike's deal, anyway? And what happens when adult video starlets meet their fans in person? Essays that are also enthralling narrative adventures.",
             "title": "Consider the Lobster and Other Essays"
           },
           {
-            "_docID": "bae-c26135f1-59d6-5f32-a7c0-16dbec525abe",
-            "plot": "A gargantuan, mind-altering tragi-comedy about the Pursuit of Happiness in America.",
-            "title": "Infinite Jest"
+            "_docID": "bae-b4966436-f962-506a-aaca-57f55a61e079",
+            "plot": "Remarkable and unsettling reimaginations of reality.",
+            "title": "Girl with Curious Hair"
+          },
+          {
+            "_docID": "bae-a93f55aa-c7e1-50ae-9056-6871b0c9da8e",
+            "plot": "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
+            "title": "Les Misérables"
           }
         ]
       }
@@ -344,10 +361,13 @@ If a document contains a relationship to another document, the return fields can
       {
         "authoredBooks": [
           {
+            "title": "Infinite Jest"
+          },
+          {
             "title": "Consider the Lobster and Other Essays"
           },
           {
-            "title": "Infinite Jest"
+            "title": "Girl with Curious Hair"
           }
         ],
         "name": "David Foster Wallace"
@@ -367,7 +387,7 @@ If a document contains a relationship to another document, the return fields can
 
 You can walk connected types without boundaries: if type `Person` has a relationships with type `Book`, which has a relationship with type `Company`, you can query `Person` and return `Person.Book.Company.<field>`. The result will reflect the nested structure of the documents.
 
-```graphql title="Retrieve all persons and the titles of their authored books"
+```graphql title="Retrieve all persons, their authored books, and the related sellers"
 {
   Person {
     authoredBooks {
@@ -388,13 +408,13 @@ You can walk connected types without boundaries: if type `Person` has a relation
         "authoredBooks": [
           {
             "seller": {
-              "name": "The Indipendent Hipster Bookshop"
+              "name": "The Independent Hipster Bookshop"
             },
             "title": "1984"
           },
           {
             "seller": {
-              "name": "The Indipendent Hipster Bookshop"
+              "name": "The Independent Hipster Bookshop"
             },
             "title": "Down and Out in Paris and London"
           }
@@ -405,7 +425,7 @@ You can walk connected types without boundaries: if type `Person` has a relation
         "authoredBooks": [
           {
             "seller": {
-              "name": "The World-Destroying Large Chain"
+              "name": "The Independent Hipster Bookshop"
             },
             "title": "Lord of the Flies"
           }
@@ -418,13 +438,19 @@ You can walk connected types without boundaries: if type `Person` has a relation
             "seller": {
               "name": "The World-Destroying Large Chain"
             },
+            "title": "Infinite Jest"
+          },
+          {
+            "seller": {
+              "name": "The World-Destroying Large Chain"
+            },
             "title": "Consider the Lobster and Other Essays"
           },
           {
             "seller": {
-              "name": "The Indipendent Hipster Bookshop"
+              "name": "The World-Destroying Large Chain"
             },
-            "title": "Infinite Jest"
+            "title": "Girl with Curious Hair"
           }
         ],
         "name": "David Foster Wallace"
@@ -452,7 +478,7 @@ Query the database for a specific document ID via the `docID` argument in the ty
 ```graphql title="Get one author by ID and return his books"
 {
   # highlight-next-line
-  Person(docID: "bae-3517d1eb-351b-5231-8387-870893ffb395") {
+  Person(docID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6") {
     name
     authoredBooks { title }
   }
@@ -483,8 +509,8 @@ Query the database for a specific document ID via the `docID` argument in the ty
   Person(
     # highlight-start
     docID: [
-      "bae-3517d1eb-351b-5231-8387-870893ffb395",
-      "bae-b59928dc-fd05-5fb7-aea2-9b24af5ebcea"
+      "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      "bae-26c791a7-fa81-5d86-95c5-4119e2fef915"
     ]
     # highlight-end
   ) {
@@ -511,10 +537,13 @@ Query the database for a specific document ID via the `docID` argument in the ty
       {
         "authoredBooks": [
           {
+            "title": "Infinite Jest"
+          },
+          {
             "title": "Consider the Lobster and Other Essays"
           },
           {
-            "title": "Infinite Jest"
+            "title": "Girl with Curious Hair"
           }
         ],
         "name": "David Foster Wallace"

--- a/docs/defradb/dql/mutation-update.md
+++ b/docs/defradb/dql/mutation-update.md
@@ -30,100 +30,110 @@ To remove a field from a document, set its value to `null`.
 <details>
   <summary>Display database setup</summary>
   
-  This page assumes your database contains `Book` and `Person` [collections](/schema/collections.md) and some documents in them:
+  To reproduce the example results from this page, your database needs the following setup.
 
   ```graphql title="Database schema" test-setup-collection
-  type Person {
-    name: String!
-    authoredBooks: [Book]
-  }
-
   type Book {
     title: String!
     genre: String
     plot: String
     rating: Float
+    ratings: [Float]
     author: Person
+    seller: Company
+  }
+  
+  type Person {
+    name: String!
+    authoredBooks: [Book]
+  }
+
+  type Company {
+    name: String!
+    sells: [Book]
   }
   ```
-  ```graphql title="Person documents setup" test-setup-data
+  ```graphql title="Documents setup" test-setup-data
   mutation {
     a1:add_Person(input: {
       name: "George Orwell"
-    }) { _docID }
+    }) { _docID name }
     a2:add_Person(input: {
       name: "William Golding"
-    }) { _docID }
+    }) { _docID name }
     a3:add_Person(input: {
       name: "David Foster Wallace"
-    }) { _docID }
+    }) { _docID name }
     a4:add_Person(input: {
       name: "Victor Hugo"
-    }) { _docID }
-  }
-  ```
-  ```graphql title="Book documents setup" test-setup-data
-  mutation {
+    }) { _docID name }
+
+    c1:add_Company(input: {
+      name: "The Independent Hipster Bookshop"
+    }) { _docID name }
+    c2:add_Company(input: {
+      name: "The World-Destroying Large Chain"
+    }) { _docID name }
+  
     b11:add_Book(input: {
       title: "1984",
       genre: "Fiction",
       plot: "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
       rating: 4.20,
-      _authorID: "bae-3517d1eb-351b-5231-8387-870893ffb395"
-    }) {
-      _docID
-      title
-    }
+      ratings: [3.8, 4.91, 3.1, 2.8],
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b12:add_Book(input: {
       title: "Down and Out in Paris and London",
-      genre: "Biography",
+      genre: "Memoir",
       plot: "The adventures of a penniless British writer among the down-and-outs of two great cities.",
       rating: 4.09,
-      _authorID: "bae-3517d1eb-351b-5231-8387-870893ffb395"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b21:add_Book(input: {
       title: "Lord of the Flies",
       genre: "Fiction",
       plot: "At the dawn of the next world war, a plane crashes on an uncharted island, stranding a group of schoolboys.",
       rating: 3.70,
-      _authorID: "bae-78e9c7be-10b9-5673-bad2-da3341367d4b"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-6025af65-e57e-5db5-84dd-d349b130c6d9",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b31:add_Book(input: {
       title: "Infinite Jest",
       genre: "Fiction",
       plot: "A gargantuan, mind-altering tragi-comedy about the Pursuit of Happiness in America.",
-      rating: 4.25
-      _authorID: "bae-b59928dc-fd05-5fb7-aea2-9b24af5ebcea"
-    }) {
-      _docID
-      title
-    }
+      rating: 4.25,
+      ratings: [3.1, 4.1, 4.5],
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b32:add_Book(input: {
       title: "Consider the Lobster and Other Essays",
       genre: "Nonfiction",
       plot: "Do lobsters feel pain? Did Franz Kafka have a funny bone? What is John Updike's deal, anyway? And what happens when adult video starlets meet their fans in person? Essays that are also enthralling narrative adventures.",
       rating: 4.18,
-      _authorID: "bae-b59928dc-fd05-5fb7-aea2-9b24af5ebcea"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
+    b33:add_Book(input: {
+      title: "Girl with Curious Hair",
+      genre: "Fiction",
+      plot: "Remarkable and unsettling reimaginations of reality.",
+      rating: 3.85,
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b41:add_Book(input: {
       title: "Les Misérables",
       genre: "Fiction",
       plot: "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
       rating: 4.21,
-      _authorID: "bae-c169e917-df52-5603-9224-39c1757f1b04"
-    }) {
-      _docID
-      title
-    }
+      ratings: [3.9, 4.1],
+      _authorID: "bae-4bfe5f4c-d668-5dc3-9de2-eb598af3da7d",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
   }
   ```
 </details>
@@ -180,7 +190,7 @@ mutation {
 ```graphql title="Update genre for several books via their docIDs"
 mutation {
   update_Book(
-    docID: ["bae-49bbd74a-64a5-5d84-83bd-08319b2e413b", "bae-1515e526-1107-54fb-b582-60b3f967c3b1"],
+    docID: ["bae-97eeb5cb-04cf-5575-ab00-3e3285ce79b5", "bae-7da5622a-8e4f-5ac8-9140-d412a81011be"],
     input: { genre: "Dystopia" }
   ) {
     genre
@@ -194,11 +204,11 @@ mutation {
     "update_Book": [
       {
         "genre": "Dystopia",
-        "title": "Lord of the Flies"
+        "title": "1984"
       },
       {
         "genre": "Dystopia",
-        "title": "1984"
+        "title": "Lord of the Flies"
       }
     ]
   }

--- a/docs/defradb/dql/order.md
+++ b/docs/defradb/dql/order.md
@@ -8,100 +8,110 @@ The `order` object allows you to specify an ordering for documents returned by a
 <details>
   <summary>Display database setup</summary>
   
-  This page assumes your database contains `Book` and `Person` [collections](/schema/collections.md) and some documents in them:
+  To reproduce the example results from this page, your database needs the following setup.
 
   ```graphql title="Database schema" test-setup-collection
-  type Person {
-    name: String!
-    authoredBooks: [Book]
-  }
-
   type Book {
     title: String!
     genre: String
     plot: String
     rating: Float
+    ratings: [Float]
     author: Person
+    seller: Company
+  }
+  
+  type Person {
+    name: String!
+    authoredBooks: [Book]
+  }
+
+  type Company {
+    name: String!
+    sells: [Book]
   }
   ```
-  ```graphql title="Person documents setup" test-setup-data
+  ```graphql title="Documents setup" test-setup-data
   mutation {
     a1:add_Person(input: {
       name: "George Orwell"
-    }) { _docID }
+    }) { _docID name }
     a2:add_Person(input: {
       name: "William Golding"
-    }) { _docID }
+    }) { _docID name }
     a3:add_Person(input: {
       name: "David Foster Wallace"
-    }) { _docID }
+    }) { _docID name }
     a4:add_Person(input: {
       name: "Victor Hugo"
-    }) { _docID }
-  }
-  ```
-  ```graphql title="Book documents setup" test-setup-data
-  mutation {
+    }) { _docID name }
+
+    c1:add_Company(input: {
+      name: "The Independent Hipster Bookshop"
+    }) { _docID name }
+    c2:add_Company(input: {
+      name: "The World-Destroying Large Chain"
+    }) { _docID name }
+  
     b11:add_Book(input: {
       title: "1984",
       genre: "Fiction",
       plot: "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
       rating: 4.20,
-      _authorID: "bae-3517d1eb-351b-5231-8387-870893ffb395"
-    }) {
-      _docID
-      title
-    }
+      ratings: [3.8, 4.91, 3.1, 2.8],
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b12:add_Book(input: {
       title: "Down and Out in Paris and London",
-      genre: "Biography",
+      genre: "Memoir",
       plot: "The adventures of a penniless British writer among the down-and-outs of two great cities.",
       rating: 4.09,
-      _authorID: "bae-3517d1eb-351b-5231-8387-870893ffb395"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b21:add_Book(input: {
       title: "Lord of the Flies",
       genre: "Fiction",
       plot: "At the dawn of the next world war, a plane crashes on an uncharted island, stranding a group of schoolboys.",
       rating: 3.70,
-      _authorID: "bae-78e9c7be-10b9-5673-bad2-da3341367d4b"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-6025af65-e57e-5db5-84dd-d349b130c6d9",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
+    }) { _docID title }
     b31:add_Book(input: {
       title: "Infinite Jest",
       genre: "Fiction",
       plot: "A gargantuan, mind-altering tragi-comedy about the Pursuit of Happiness in America.",
-      rating: 4.25
-      _authorID: "bae-b59928dc-fd05-5fb7-aea2-9b24af5ebcea"
-    }) {
-      _docID
-      title
-    }
+      rating: 4.25,
+      ratings: [3.1, 4.1, 4.5],
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b32:add_Book(input: {
       title: "Consider the Lobster and Other Essays",
       genre: "Nonfiction",
       plot: "Do lobsters feel pain? Did Franz Kafka have a funny bone? What is John Updike's deal, anyway? And what happens when adult video starlets meet their fans in person? Essays that are also enthralling narrative adventures.",
       rating: 4.18,
-      _authorID: "bae-b59928dc-fd05-5fb7-aea2-9b24af5ebcea"
-    }) {
-      _docID
-      title
-    }
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
+    b33:add_Book(input: {
+      title: "Girl with Curious Hair",
+      genre: "Fiction",
+      plot: "Remarkable and unsettling reimaginations of reality.",
+      rating: 3.85,
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
     b41:add_Book(input: {
       title: "Les Misérables",
       genre: "Fiction",
       plot: "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
       rating: 4.21,
-      _authorID: "bae-c169e917-df52-5603-9224-39c1757f1b04"
-    }) {
-      _docID
-      title
-    }
+      ratings: [3.9, 4.1],
+      _authorID: "bae-4bfe5f4c-d668-5dc3-9de2-eb598af3da7d",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
   }
   ```
 </details>
@@ -134,6 +144,9 @@ To order results, use the syntax `order: { fieldName: DIRECTION }`, where:
         "title": "Down and Out in Paris and London"
       },
       {
+        "title": "Girl with Curious Hair"
+      },
+      {
         "title": "Infinite Jest"
       },
       {
@@ -154,7 +167,6 @@ You can specify a field for secondary order by providing a list of objects to th
 ```graphql title="Sort books on genre first, and then on title"
 {
   Book(order: [{ genre: ASC }, { title: ASC }], limit: 4) {
-    _docID
     title
     genre
   }
@@ -165,26 +177,19 @@ You can specify a field for secondary order by providing a list of objects to th
   "data": {
     "Book": [
       {
-        "_docID": "bae-32df1584-35fc-5a12-b1e5-e8b00f4b9a48",
-        "genre": "Biography",
-        "title": "Down and Out in Paris and London"
-      },
-      {
-        "_docID": "bae-49bbd74a-64a5-5d84-83bd-08319b2e413b",
         "genre": "Fiction",
-        // highlight-next-line
         "title": "1984"
       },
       {
-        "_docID": "bae-c098a085-0f2c-5460-8bb9-a15d2861e7ac",
         "genre": "Fiction",
-        // highlight-next-line
+        "title": "Girl with Curious Hair"
+      },
+      {
+        "genre": "Fiction",
         "title": "Infinite Jest"
       },
       {
-        "_docID": "bae-99a36f4d-54c6-5d54-8b9d-cceab63aa86f",
         "genre": "Fiction",
-        // highlight-next-line
         "title": "Les Misérables"
       }
     ]

--- a/docs/defradb/dql/variables.md
+++ b/docs/defradb/dql/variables.md
@@ -14,9 +14,19 @@ The best practice is thus to use variables for all values that might change over
 <details>
   <summary>Display database setup</summary>
   
-  This page assumes your database contains `Book` and `Person` [collections](/schema/collections.md) and some documents in them:
+  To reproduce the example results from this page, your database needs the following setup.
 
   ```graphql title="Database schema" test-setup-collection
+  type Book {
+    title: String!
+    genre: String
+    plot: String
+    rating: Float
+    ratings: [Float]
+    author: Person
+    seller: Company
+  }
+  
   type Person {
     name: String!
     authoredBooks: [Book]
@@ -26,25 +36,9 @@ The best practice is thus to use variables for all values that might change over
     name: String!
     sells: [Book]
   }
-
-  type Book {
-    title: String!
-    genre: String
-    plot: String
-    rating: Float
-    author: Person
-    seller: Company
-  }
   ```
   ```graphql title="Documents setup" test-setup-data
   mutation {
-    c1:add_Company(input: {
-      name: "The Indipendent Hipster Bookshop"
-    }) { _docID name }
-    c2:add_Company(input: {
-      name: "The World-Destroying Large Chain"
-    }) { _docID name }
-
     a1:add_Person(input: {
       name: "George Orwell"
     }) { _docID name }
@@ -58,53 +52,71 @@ The best practice is thus to use variables for all values that might change over
       name: "Victor Hugo"
     }) { _docID name }
 
+    c1:add_Company(input: {
+      name: "The Independent Hipster Bookshop"
+    }) { _docID name }
+    c2:add_Company(input: {
+      name: "The World-Destroying Large Chain"
+    }) { _docID name }
+  
     b11:add_Book(input: {
       title: "1984",
       genre: "Fiction",
       plot: "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
       rating: 4.20,
-      _authorID: "bae-f630242e-3faf-525e-864c-422e09b00667",
-      _sellerID: "bae-e2120437-8282-5e59-9e02-e98d82f73cc3"
+      ratings: [3.8, 4.91, 3.1, 2.8],
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
     }) { _docID title }
     b12:add_Book(input: {
       title: "Down and Out in Paris and London",
-      genre: "Biography",
+      genre: "Memoir",
       plot: "The adventures of a penniless British writer among the down-and-outs of two great cities.",
       rating: 4.09,
-      _authorID: "bae-f630242e-3faf-525e-864c-422e09b00667",
-      _sellerID: "bae-e2120437-8282-5e59-9e02-e98d82f73cc3"
+      _authorID: "bae-bc532931-4843-50bc-bbdd-3e31549c8cc6",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
     }) { _docID title }
     b21:add_Book(input: {
       title: "Lord of the Flies",
       genre: "Fiction",
       plot: "At the dawn of the next world war, a plane crashes on an uncharted island, stranding a group of schoolboys.",
       rating: 3.70,
-      _authorID: "bae-db573e8d-2466-55b9-8da0-39003f530d44",
-      _sellerID: "bae-f8755a60-c49f-510f-a435-c4ddfec82499"
+      _authorID: "bae-6025af65-e57e-5db5-84dd-d349b130c6d9",
+      _sellerID: "bae-a5300933-fb0a-5b8f-b38e-202565993ff0"
     }) { _docID title }
     b31:add_Book(input: {
       title: "Infinite Jest",
       genre: "Fiction",
       plot: "A gargantuan, mind-altering tragi-comedy about the Pursuit of Happiness in America.",
-      rating: 4.25
-      _authorID: "bae-40b16347-07e0-5e97-85e0-8742eaba786e",
-      _sellerID: "bae-e2120437-8282-5e59-9e02-e98d82f73cc3"
+      rating: 4.25,
+      ratings: [3.1, 4.1, 4.5],
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
     }) { _docID title }
     b32:add_Book(input: {
       title: "Consider the Lobster and Other Essays",
       genre: "Nonfiction",
       plot: "Do lobsters feel pain? Did Franz Kafka have a funny bone? What is John Updike's deal, anyway? And what happens when adult video starlets meet their fans in person? Essays that are also enthralling narrative adventures.",
       rating: 4.18,
-      _authorID: "bae-40b16347-07e0-5e97-85e0-8742eaba786e",
-      _sellerID: "bae-f8755a60-c49f-510f-a435-c4ddfec82499"
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
+    }) { _docID title }
+    b33:add_Book(input: {
+      title: "Girl with Curious Hair",
+      genre: "Fiction",
+      plot: "Remarkable and unsettling reimaginations of reality.",
+      rating: 3.85,
+      _authorID: "bae-26c791a7-fa81-5d86-95c5-4119e2fef915",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
     }) { _docID title }
     b41:add_Book(input: {
       title: "Les Misérables",
       genre: "Fiction",
       plot: "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
       rating: 4.21,
-      _authorID: "bae-7f9e6642-03e3-5f62-b684-3d5555f46f7d",
-      _sellerID: "bae-f8755a60-c49f-510f-a435-c4ddfec82499"
+      ratings: [3.9, 4.1],
+      _authorID: "bae-4bfe5f4c-d668-5dc3-9de2-eb598af3da7d",
+      _sellerID: "bae-81d5fadb-c2a3-5d95-b235-a220c220bf79"
     }) { _docID title }
   }
   ```
@@ -131,7 +143,7 @@ query ($bookID: [ID!]) {
 ```
 ```json title="Variables"
 {
-  "bookID": "bae-b99349d9-9419-52c3-9b53-7a9b28e0ea33"
+  "bookID": "bae-d1460b1a-8f78-5791-b0ec-869997260c20"
 }
 ```
 ```json title="Result"
@@ -139,7 +151,7 @@ query ($bookID: [ID!]) {
   "data": {
     "Book": [
       {
-        "_docID": "bae-b99349d9-9419-52c3-9b53-7a9b28e0ea33",
+        "_docID": "bae-d1460b1a-8f78-5791-b0ec-869997260c20",
         "author": {
           "name": "David Foster Wallace"
         },
@@ -212,9 +224,9 @@ query ($plot: String, $minRating: Float64) {
   "data": {
     "Book": [
       {
-        "plot": "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
-        "rating": 4.21,
-        "title": "Les Misérables"
+        "plot": "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
+        "rating": 4.2,
+        "title": "1984"
       },
       {
         "plot": "A gargantuan, mind-altering tragi-comedy about the Pursuit of Happiness in America.",
@@ -222,9 +234,9 @@ query ($plot: String, $minRating: Float64) {
         "title": "Infinite Jest"
       },
       {
-        "plot": "A masterpiece of rebellion and imprisonment where war is peace, freedom is slavery, and Big Brother is watching.",
-        "rating": 4.2,
-        "title": "1984"
+        "plot": "Victor Hugo's tale of injustice, heroism and love follows the fortunes of Jean Valjean, an escaped convict determined to put his criminal past behind him.",
+        "rating": 4.21,
+        "title": "Les Misérables"
       }
     ]
   }


### PR DESCRIPTION
Almost all DQL pages now share the same collections+docs setup, and all results were updated to reflect that, while removing `_docID` from results when there was no display value to it.