### PR TITLE
Add Umami Event Tracker

### DIFF
--- a/docs/defradb/quickstart.md
+++ b/docs/defradb/quickstart.md
@@ -307,7 +307,7 @@ The DefraDB Query Language (DQL) is a rich GraphQL-based language supporting rel
   }
 }
 ```
-
+<UmamiEvent eventName="quickstart-complete" />
 [-> More information on querying documents](/dql/mutation-query.md)
 
 ## Next steps {/* #next-steps */}

--- a/docs/lensvm/lens-vm.md
+++ b/docs/lensvm/lens-vm.md
@@ -144,3 +144,6 @@ For practical examples of pipeline composition, explore the following:
 - [CLI integration tests](https://github.com/lens-vm/lens/tree/main/tests/integration/cli)
 
 These examples demonstrate how to build and extend Lens pipelines declaratively for various environments and workflows.
+
+<UmamiEvent eventName="quickstart-complete" />
+

--- a/docs/orbis/overview.md
+++ b/docs/orbis/overview.md
@@ -18,3 +18,4 @@ Once a Ring is fully configured and initialized users that want to store secrets
 The *Root Ring* is a special deployment Orbis Ring that is a public permissionless service provided by the same infrastructure nodes as the SourceHub publicly hosted service. This ensures there is a single public Source stack deployment that developers can use along side their DefraDB nodes.
 :::
 
+<UmamiEvent eventName="quickstart-complete" />

--- a/docs/sourcehub/overview.md
+++ b/docs/sourcehub/overview.md
@@ -17,3 +17,5 @@ The primary functions of SourceHub are:
 ---
 
 Although SourceHub is an independent system with self-contained functionality - like the rest of the Source Stack - it is designed to work in conjunction with [DefraDB](/defradb) nodes to help facilitate trust in its peer-to-peer architecture. 
+
+<UmamiEvent eventName="quickstart-complete" />

--- a/src/components/UmamiEvent/index.tsx
+++ b/src/components/UmamiEvent/index.tsx
@@ -1,0 +1,78 @@
+// src/components/UmamiEvent/index.tsx
+import React, { useEffect, useRef } from 'react';
+import { useLocation } from '@docusaurus/router';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+export interface UmamiEventProps {
+  /** Umami event name (required). Passed in at the call site. */
+  eventName: string;
+  /** Extra key/value data to attach to the event. */
+  eventData?: Record<string, string | number | boolean>;
+  /**
+   * Fraction of the sentinel that must be visible to count as "reached".
+   * 0 = as soon as any pixel is visible. Default 0.
+   */
+  threshold?: number;
+}
+
+/**
+ * Drop this at the bottom of any markdown/MDX page:
+ *
+ *   <UmamiEvent eventName="scroll-to-bottom" />
+ *
+ * It renders a 1px, invisible sentinel. When that sentinel scrolls into
+ * the viewport, it means the reader reached the bottom of the page, and
+ * we fire a single umami.track() call (once per page view).
+ */
+export default function UmamiEvent({
+  eventName,
+  eventData,
+  threshold = 0,
+}: UmamiEventProps): JSX.Element {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const firedRef = useRef(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!ExecutionEnvironment.canUseDOM) return;
+    if (typeof IntersectionObserver === 'undefined') return;
+
+    // Reset the "already fired" flag on every client-side navigation,
+    // since Docusaurus is an SPA and this component instance may persist
+    // across route changes if reused in a layout.
+    firedRef.current = false;
+
+    const node = sentinelRef.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting && !firedRef.current) {
+            firedRef.current = true;
+            window.umami?.track(eventName, {
+              path: location.pathname,
+              title: document.title,
+              ...eventData,
+            });
+            // Stop watching once fired — we only want it once per view.
+            observer.disconnect();
+          }
+        }
+      },
+      { threshold }
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.pathname]);
+
+  return (
+    <div
+      ref={sentinelRef}
+      aria-hidden="true"
+      style={{ height: 1, width: '100%' }}
+    />
+  );
+}

--- a/src/components/UmamiEvent/index.tsx
+++ b/src/components/UmamiEvent/index.tsx
@@ -1,18 +1,22 @@
 // src/components/UmamiEvent/index.tsx
-import React, { useEffect, useRef } from 'react';
-import { useLocation } from '@docusaurus/router';
-import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import React, { useEffect, useRef } from "react";
+import { useLocation } from "@docusaurus/router";
+import { useActivePluginAndVersion } from "@docusaurus/plugin-content-docs/client";
+import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
+
+declare global {
+  interface Window {
+    umami?: {
+      track: (eventName: string, data?: Record<string, unknown>) => void;
+    };
+  }
+}
 
 export interface UmamiEventProps {
   /** Umami event name (required). Passed in at the call site. */
   eventName: string;
   /** Extra key/value data to attach to the event. */
   eventData?: Record<string, string | number | boolean>;
-  /**
-   * Fraction of the sentinel that must be visible to count as "reached".
-   * 0 = as soon as any pixel is visible. Default 0.
-   */
-  threshold?: number;
 }
 
 /**
@@ -24,18 +28,18 @@ export interface UmamiEventProps {
  * the viewport, it means the reader reached the bottom of the page, and
  * we fire a single umami.track() call (once per page view).
  */
-export default function UmamiEvent({
-  eventName,
-  eventData,
-  threshold = 0,
-}: UmamiEventProps): JSX.Element {
+export default function UmamiEvent({ eventName, eventData }: UmamiEventProps) {
   const sentinelRef = useRef<HTMLDivElement>(null);
   const firedRef = useRef(false);
   const location = useLocation();
 
+  const active = useActivePluginAndVersion({ failfast: false });
+  const product = active?.activePlugin?.pluginId;
+  const version = active?.activeVersion?.label.replace(/\s*\(.*\)\s*$/, "");
+
   useEffect(() => {
     if (!ExecutionEnvironment.canUseDOM) return;
-    if (typeof IntersectionObserver === 'undefined') return;
+    if (typeof IntersectionObserver === "undefined") return;
 
     // Reset the "already fired" flag on every client-side navigation,
     // since Docusaurus is an SPA and this component instance may persist
@@ -51,8 +55,8 @@ export default function UmamiEvent({
           if (entry.isIntersecting && !firedRef.current) {
             firedRef.current = true;
             window.umami?.track(eventName, {
-              path: location.pathname,
-              title: document.title,
+              product,
+              version,
               ...eventData,
             });
             // Stop watching once fired — we only want it once per view.
@@ -60,7 +64,6 @@ export default function UmamiEvent({
           }
         }
       },
-      { threshold }
     );
 
     observer.observe(node);
@@ -72,7 +75,7 @@ export default function UmamiEvent({
     <div
       ref={sentinelRef}
       aria-hidden="true"
-      style={{ height: 1, width: '100%' }}
+      style={{ height: 1, width: "100%" }}
     />
   );
 }

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -5,9 +5,11 @@
 import MDXComponents from '@theme-original/MDXComponents';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import UmamiEvent from '@site/src/components/UmamiEvent';
 export default {
   // Reusing and expanding the default mapping
   ...MDXComponents,
+  ScrollTracker,
   Tabs,
   TabItem
 };

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -9,7 +9,7 @@ import UmamiEvent from '@site/src/components/UmamiEvent';
 export default {
   // Reusing and expanding the default mapping
   ...MDXComponents,
-  ScrollTracker,
+  UmamiEvent,
   Tabs,
   TabItem
 };


### PR DESCRIPTION
This PR adds an arbitrary umami event tracker component so we can track anything we see fit. 

As an example, I have added a completion event to the bottom of each quickstart that only triggers once per pageview on scroll to bottom. By doing this we can easily track the total quickstart completions. 