### PR TITLE
Fix expand code blocks button not working

### DIFF
--- a/src/plugins/code-blocks.js
+++ b/src/plugins/code-blocks.js
@@ -21,6 +21,7 @@ function collapseBlock(block) {
   // Link to expand
   let displayAll = document.createElement('div')
   displayAll.classList.add('display-all')
+  displayAll.addEventListener('click', expandBlock)
   pre.addEventListener('click', expandBlock)  // clicking anywhere on the code block expands it
   let displayAllLink = document.createElement('a')
   displayAllLink.innerHTML = `Expand (${blockLineCount(block)} lines)`


### PR DESCRIPTION
The block would not expand when clicking on the expand button, although it would work when clicking anywhere on the code block (as intended). An extra event listener on the button itself fixes the issue.