### PR TITLE
Fix link to About Us

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -150,7 +150,7 @@ const config = {
             items: [
               {
                 label: "About Us",
-                href: "https://source.network/about",
+                href: "https://source.network/our-story",
               },
               {
                 label: "Privacy Policy",


### PR DESCRIPTION
I was quite randomly going through the docs page and noticed this dead link. Unfortunately the privacy policy link is also dead but I couldn't find an alternative for it so have left it as-is